### PR TITLE
fixes typos in some modules (e.g:lower/upper case & invalid types)

### DIFF
--- a/src/xf86dga.nim
+++ b/src/xf86dga.nim
@@ -1,18 +1,18 @@
 #
 #   Copyright (c) 1999  XFree86 Inc
 #
-# $XFree86: xc/include/extensions/xf86dga.h,v 3.20 1999/10/13 04:20:48 dawes Exp $ 
+# $XFree86: xc/include/extensions/xf86dga.h,v 3.20 1999/10/13 04:20:48 dawes Exp $
 
-import 
+import
   x, xlib
 
-const 
+const
   libXxf86dga* = "libXxf86dga.so"
 
-#type 
+#type
 #  cfloat* = float32
 
-# $XFree86: xc/include/extensions/xf86dga1.h,v 1.2 1999/04/17 07:05:41 dawes Exp $ 
+# $XFree86: xc/include/extensions/xf86dga1.h,v 1.2 1999/04/17 07:05:41 dawes Exp $
 #
 #
 #Copyright (c) 1995  Jon Tombs
@@ -25,10 +25,10 @@ const
 #
 #************************************************************************
 
-type 
+type
   PPcchar* = ptr ptr cstring
 
-const 
+const
   X_XF86DGAQueryVersion* = 0
   X_XF86DGAGetVideoLL* = 1
   X_XF86DGADirectVideo* = 2
@@ -46,40 +46,40 @@ const
   XF86DGAHasColormap* = 0x00000100
   XF86DGADirectColormap* = 0x00000200
 
-proc XF86DGAQueryVersion*(dpy: PDisplay, majorVersion: Pcint, 
-                          minorVersion: Pcint): TBool{.CDecl, 
+proc XF86DGAQueryVersion*(dpy: PDisplay, majorVersion: Pcint,
+                          minorVersion: Pcint): TBool{.cdecl,
     dynlib: libXxf86dga, importc.}
 proc XF86DGAQueryExtension*(dpy: PDisplay, event_base: Pcint, error_base: Pcint): TBool{.
-    CDecl, dynlib: libXxf86dga, importc.}
-proc XF86DGAGetVideoLL*(dpy: PDisplay, screen: cint, base_addr: Pcint, 
+    cdecl, dynlib: libXxf86dga, importc.}
+proc XF86DGAGetVideoLL*(dpy: PDisplay, screen: cint, base_addr: Pcint,
                         width: Pcint, bank_size: Pcint, ram_size: Pcint): TStatus{.
-    CDecl, dynlib: libXxf86dga, importc.}
-proc XF86DGAGetVideo*(dpy: PDisplay, screen: cint, base_addr: PPcchar, 
+    cdecl, dynlib: libXxf86dga, importc.}
+proc XF86DGAGetVideo*(dpy: PDisplay, screen: cint, base_addr: PPcchar,
                       width: Pcint, bank_size: Pcint, ram_size: Pcint): TStatus{.
-    CDecl, dynlib: libXxf86dga, importc.}
+    cdecl, dynlib: libXxf86dga, importc.}
 proc XF86DGADirectVideo*(dpy: PDisplay, screen: cint, enable: cint): TStatus{.
-    CDecl, dynlib: libXxf86dga, importc.}
+    cdecl, dynlib: libXxf86dga, importc.}
 proc XF86DGADirectVideoLL*(dpy: PDisplay, screen: cint, enable: cint): TStatus{.
-    CDecl, dynlib: libXxf86dga, importc.}
-proc XF86DGAGetViewPortSize*(dpy: PDisplay, screen: cint, width: Pcint, 
-                             height: Pcint): TStatus{.CDecl, 
+    cdecl, dynlib: libXxf86dga, importc.}
+proc XF86DGAGetViewPortSize*(dpy: PDisplay, screen: cint, width: Pcint,
+                             height: Pcint): TStatus{.cdecl,
     dynlib: libXxf86dga, importc.}
 proc XF86DGASetViewPort*(dpy: PDisplay, screen: cint, x: cint, y: cint): TStatus{.
-    CDecl, dynlib: libXxf86dga, importc.}
+    cdecl, dynlib: libXxf86dga, importc.}
 proc XF86DGAGetVidPage*(dpy: PDisplay, screen: cint, vid_page: Pcint): TStatus{.
-    CDecl, dynlib: libXxf86dga, importc.}
+    cdecl, dynlib: libXxf86dga, importc.}
 proc XF86DGASetVidPage*(dpy: PDisplay, screen: cint, vid_page: cint): TStatus{.
-    CDecl, dynlib: libXxf86dga, importc.}
+    cdecl, dynlib: libXxf86dga, importc.}
 proc XF86DGAInstallColormap*(dpy: PDisplay, screen: cint, Colormap: TColormap): TStatus{.
-    CDecl, dynlib: libXxf86dga, importc.}
-proc XF86DGAForkApp*(screen: cint): cint{.CDecl, dynlib: libXxf86dga, importc.}
+    cdecl, dynlib: libXxf86dga, importc.}
+proc XF86DGAForkApp*(screen: cint): cint{.cdecl, dynlib: libXxf86dga, importc.}
 proc XF86DGAQueryDirectVideo*(dpy: PDisplay, screen: cint, flags: Pcint): TStatus{.
-    CDecl, dynlib: libXxf86dga, importc.}
+    cdecl, dynlib: libXxf86dga, importc.}
 proc XF86DGAViewPortChanged*(dpy: PDisplay, screen: cint, n: cint): TBool{.
-    CDecl, dynlib: libXxf86dga, importc.}
-const 
-  X_XDGAQueryVersion* = 0     # 1 through 9 are in xf86dga1.pp 
-                              # 10 and 11 are reserved to avoid conflicts with rogue DGA extensions 
+    cdecl, dynlib: libXxf86dga, importc.}
+const
+  X_XDGAQueryVersion* = 0     # 1 through 9 are in xf86dga1.pp
+                              # 10 and 11 are reserved to avoid conflicts with rogue DGA extensions
   X_XDGAQueryModes* = 12
   X_XDGASetMode* = 13
   X_XDGASetViewport* = 14
@@ -115,19 +115,19 @@ const
   XF86DGAOperationNotSupported* = 4
   XF86DGANumberErrors* = (XF86DGAOperationNotSupported + 1)
 
-type 
+type
   PXDGAMode* = ptr TXDGAMode
-  TXDGAMode*{.final.} = object 
-    num*: cint                # A unique identifier for the mode (num > 0) 
-    name*: cstring            # name of mode given in the XF86Config 
+  TXDGAMode*{.final.} = object
+    num*: cint                # A unique identifier for the mode (num > 0)
+    name*: cstring            # name of mode given in the XF86Config
     verticalRefresh*: cfloat
-    flags*: cint              # DGA_CONCURRENT_ACCESS, etc... 
-    imageWidth*: cint         # linear accessible portion (pixels) 
+    flags*: cint              # DGA_CONCURRENT_ACCESS, etc...
+    imageWidth*: cint         # linear accessible portion (pixels)
     imageHeight*: cint
-    pixmapWidth*: cint        # Xlib accessible portion (pixels) 
-    pixmapHeight*: cint       # both fields ignored if no concurrent access 
+    pixmapWidth*: cint        # Xlib accessible portion (pixels)
+    pixmapHeight*: cint       # both fields ignored if no concurrent access
     bytesPerScanline*: cint
-    byteOrder*: cint          # MSBFirst, LSBFirst 
+    byteOrder*: cint          # MSBFirst, LSBFirst
     depth*: cint
     bitsPerPixel*: cint
     redMask*: culong
@@ -136,22 +136,22 @@ type
     visualClass*: cshort
     viewportWidth*: cint
     viewportHeight*: cint
-    xViewportStep*: cint      # viewport position granularity 
+    xViewportStep*: cint      # viewport position granularity
     yViewportStep*: cint
-    maxViewportX*: cint       # max viewport origin 
+    maxViewportX*: cint       # max viewport origin
     maxViewportY*: cint
-    viewportFlags*: cint      # types of page flipping possible 
+    viewportFlags*: cint      # types of page flipping possible
     reserved1*: cint
     reserved2*: cint
 
   PXDGADevice* = ptr TXDGADevice
-  TXDGADevice*{.final.} = object 
+  TXDGADevice*{.final.} = object
     mode*: TXDGAMode
     data*: Pcuchar
     pixmap*: TPixmap
 
   PXDGAButtonEvent* = ptr TXDGAButtonEvent
-  TXDGAButtonEvent*{.final.} = object 
+  TXDGAButtonEvent*{.final.} = object
     theType*: cint
     serial*: culong
     display*: PDisplay
@@ -161,7 +161,7 @@ type
     button*: cuint
 
   PXDGAKeyEvent* = ptr TXDGAKeyEvent
-  TXDGAKeyEvent*{.final.} = object 
+  TXDGAKeyEvent*{.final.} = object
     theType*: cint
     serial*: culong
     display*: PDisplay
@@ -171,7 +171,7 @@ type
     keycode*: cuint
 
   PXDGAMotionEvent* = ptr TXDGAMotionEvent
-  TXDGAMotionEvent*{.final.} = object 
+  TXDGAMotionEvent*{.final.} = object
     theType*: cint
     serial*: culong
     display*: PDisplay
@@ -182,7 +182,7 @@ type
     dy*: cint
 
   PXDGAEvent* = ptr TXDGAEvent
-  TXDGAEvent*{.final.} = object 
+  TXDGAEvent*{.final.} = object
     pad*: array[0..23, clong] # sorry you have to cast if you want access
                               #Case LongInt Of
                               #      0 : (_type : cint);
@@ -190,46 +190,46 @@ type
                               #      2 : (xkey : TXDGAKeyEvent);
                               #      3 : (xmotion : TXDGAMotionEvent);
                               #      4 : (pad : Array[0..23] Of clong);
-  
+
 
 proc XDGAQueryExtension*(dpy: PDisplay, eventBase: Pcint, erroBase: Pcint): TBool{.
-    CDecl, dynlib: libXxf86dga, importc.}
+    cdecl, dynlib: libXxf86dga, importc.}
 proc XDGAQueryVersion*(dpy: PDisplay, majorVersion: Pcint, minorVersion: Pcint): TBool{.
-    CDecl, dynlib: libXxf86dga, importc.}
-proc XDGAQueryModes*(dpy: PDisplay, screen: cint, num: Pcint): PXDGAMode{.CDecl, 
+    cdecl, dynlib: libXxf86dga, importc.}
+proc XDGAQueryModes*(dpy: PDisplay, screen: cint, num: Pcint): PXDGAMode{.cdecl,
     dynlib: libXxf86dga, importc.}
-proc XDGASetMode*(dpy: PDisplay, screen: cint, mode: cint): PXDGADevice{.CDecl, 
+proc XDGASetMode*(dpy: PDisplay, screen: cint, mode: cint): PXDGADevice{.cdecl,
     dynlib: libXxf86dga, importc.}
-proc XDGAOpenFramebuffer*(dpy: PDisplay, screen: cint): TBool{.CDecl, 
+proc XDGAOpenFramebuffer*(dpy: PDisplay, screen: cint): TBool{.cdecl,
     dynlib: libXxf86dga, importc.}
-proc XDGACloseFramebuffer*(dpy: PDisplay, screen: cint){.CDecl, 
+proc XDGACloseFramebuffer*(dpy: PDisplay, screen: cint){.cdecl,
     dynlib: libXxf86dga, importc.}
 proc XDGASetViewport*(dpy: PDisplay, screen: cint, x: cint, y: cint, flags: cint){.
-    CDecl, dynlib: libXxf86dga, importc.}
-proc XDGAInstallColormap*(dpy: PDisplay, screen: cint, cmap: TColormap){.CDecl, 
+    cdecl, dynlib: libXxf86dga, importc.}
+proc XDGAInstallColormap*(dpy: PDisplay, screen: cint, cmap: TColormap){.cdecl,
     dynlib: libXxf86dga, importc.}
-proc XDGACreateColormap*(dpy: PDisplay, screen: cint, device: PXDGADevice, 
-                         alloc: cint): TColormap{.CDecl, dynlib: libXxf86dga, 
+proc XDGACreateColormap*(dpy: PDisplay, screen: cint, device: PXDGADevice,
+                         alloc: cint): TColormap{.cdecl, dynlib: libXxf86dga,
     importc.}
-proc XDGASelectInput*(dpy: PDisplay, screen: cint, event_mask: clong){.CDecl, 
+proc XDGASelectInput*(dpy: PDisplay, screen: cint, event_mask: clong){.cdecl,
     dynlib: libXxf86dga, importc.}
-proc XDGAFillRectangle*(dpy: PDisplay, screen: cint, x: cint, y: cint, 
-                        width: cuint, height: cuint, color: culong){.CDecl, 
+proc XDGAFillRectangle*(dpy: PDisplay, screen: cint, x: cint, y: cint,
+                        width: cuint, height: cuint, color: culong){.cdecl,
     dynlib: libXxf86dga, importc.}
-proc XDGACopyArea*(dpy: PDisplay, screen: cint, srcx: cint, srcy: cint, 
-                   width: cuint, height: cuint, dstx: cint, dsty: cint){.CDecl, 
+proc XDGACopyArea*(dpy: PDisplay, screen: cint, srcx: cint, srcy: cint,
+                   width: cuint, height: cuint, dstx: cint, dsty: cint){.cdecl,
     dynlib: libXxf86dga, importc.}
-proc XDGACopyTransparentArea*(dpy: PDisplay, screen: cint, srcx: cint, 
-                              srcy: cint, width: cuint, height: cuint, 
-                              dstx: cint, dsty: cint, key: culong){.CDecl, 
+proc XDGACopyTransparentArea*(dpy: PDisplay, screen: cint, srcx: cint,
+                              srcy: cint, width: cuint, height: cuint,
+                              dstx: cint, dsty: cint, key: culong){.cdecl,
     dynlib: libXxf86dga, importc.}
-proc XDGAGetViewportStatus*(dpy: PDisplay, screen: cint): cint{.CDecl, 
+proc XDGAGetViewportStatus*(dpy: PDisplay, screen: cint): cint{.cdecl,
     dynlib: libXxf86dga, importc.}
-proc XDGASync*(dpy: PDisplay, screen: cint){.CDecl, dynlib: libXxf86dga, importc.}
-proc XDGASetClientVersion*(dpy: PDisplay): TBool{.CDecl, dynlib: libXxf86dga, 
+proc XDGASync*(dpy: PDisplay, screen: cint){.cdecl, dynlib: libXxf86dga, importc.}
+proc XDGASetClientVersion*(dpy: PDisplay): TBool{.cdecl, dynlib: libXxf86dga,
     importc.}
-proc XDGAChangePixmapMode*(dpy: PDisplay, screen: cint, x: Pcint, y: Pcint, 
-                           mode: cint){.CDecl, dynlib: libXxf86dga, importc.}
-proc XDGAKeyEventToXKeyEvent*(dk: PXDGAKeyEvent, xk: PXKeyEvent){.CDecl, 
+proc XDGAChangePixmapMode*(dpy: PDisplay, screen: cint, x: Pcint, y: Pcint,
+                           mode: cint){.cdecl, dynlib: libXxf86dga, importc.}
+proc XDGAKeyEventToXKeyEvent*(dk: PXDGAKeyEvent, xk: PXKeyEvent){.cdecl,
     dynlib: libXxf86dga, importc.}
 # implementation

--- a/src/xf86vmode.nim
+++ b/src/xf86vmode.nim
@@ -1,4 +1,4 @@
-# $XFree86: xc/include/extensions/xf86vmode.h,v 3.30 2001/05/07 20:09:50 mvojkovi Exp $ 
+# $XFree86: xc/include/extensions/xf86vmode.h,v 3.30 2001/05/07 20:09:50 mvojkovi Exp $
 #
 #
 #Copyright 1995  Kaleb S. KEITHLEY
@@ -17,30 +17,30 @@
 #THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 #EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 #MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-#IN NO EVENT SHALL Kaleb S. KEITHLEY BE LIABLE FOR ANY CLAIM, DAMAGES 
+#IN NO EVENT SHALL Kaleb S. KEITHLEY BE LIABLE FOR ANY CLAIM, DAMAGES
 #OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 #ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 #OTHER DEALINGS IN THE SOFTWARE.
 #
-#Except as contained in this notice, the name of Kaleb S. KEITHLEY 
-#shall not be used in advertising or otherwise to promote the sale, use 
+#Except as contained in this notice, the name of Kaleb S. KEITHLEY
+#shall not be used in advertising or otherwise to promote the sale, use
 #or other dealings in this Software without prior written authorization
 #from Kaleb S. KEITHLEY
 #
 #
-# $Xorg: xf86vmode.h,v 1.3 2000/08/18 04:05:46 coskrey Exp $ 
-# THIS IS NOT AN X CONSORTIUM STANDARD OR AN X PROJECT TEAM SPECIFICATION 
+# $Xorg: xf86vmode.h,v 1.3 2000/08/18 04:05:46 coskrey Exp $
+# THIS IS NOT AN X CONSORTIUM STANDARD OR AN X PROJECT TEAM SPECIFICATION
 
-import 
+import
   x, xlib
 
-const 
+const
   libXxf86vm* = "libXxf86vm.so"
 
-type 
+type
   PINT32* = ptr int32
 
-const 
+const
   X_XF86VidModeQueryVersion* = 0
   X_XF86VidModeGetModeLine* = 1
   X_XF86VidModeModModeLine* = 2
@@ -53,7 +53,7 @@ const
   X_XF86VidModeValidateModeLine* = 9
   X_XF86VidModeSwitchToMode* = 10
   X_XF86VidModeGetViewPort* = 11
-  X_XF86VidModeSetViewPort* = 12 # new for version 2.x of this extension 
+  X_XF86VidModeSetViewPort* = 12 # new for version 2.x of this extension
   X_XF86VidModeGetDotClocks* = 13
   X_XF86VidModeSetClientVersion* = 14
   X_XF86VidModeSetGamma* = 15
@@ -64,17 +64,17 @@ const
   X_XF86VidModeGetPermissions* = 20
   CLKFLAG_PROGRAMABLE* = 1
 
-when defined(XF86VIDMODE_EVENTS): 
-  const 
+when defined(XF86VIDMODE_EVENTS):
+  const
     XF86VidModeNotify* = 0
     XF86VidModeNumberEvents* = (XF86VidModeNotify + 1)
     XF86VidModeNotifyMask* = 0x00000001
     XF86VidModeNonEvent* = 0
     XF86VidModeModeChange* = 1
-else: 
-  const 
+else:
+  const
     XF86VidModeNumberEvents* = 0
-const 
+const
   XF86VidModeBadClock* = 0
   XF86VidModeBadHTimings* = 1
   XF86VidModeBadVTimings* = 2
@@ -86,9 +86,9 @@ const
   XF86VM_READ_PERMISSION* = 1
   XF86VM_WRITE_PERMISSION* = 2
 
-type 
+type
   PXF86VidModeModeLine* = ptr TXF86VidModeModeLine
-  TXF86VidModeModeLine*{.final.} = object 
+  TXF86VidModeModeLine*{.final.} = object
     hdisplay*: cushort
     hsyncstart*: cushort
     hsyncend*: cushort
@@ -105,7 +105,7 @@ type
   PPPXF86VidModeModeInfo* = ptr PPXF86VidModeModeInfo
   PPXF86VidModeModeInfo* = ptr PXF86VidModeModeInfo
   PXF86VidModeModeInfo* = ptr TXF86VidModeModeInfo
-  TXF86VidModeModeInfo*{.final.} = object 
+  TXF86VidModeModeInfo*{.final.} = object
     dotclock*: cuint
     hdisplay*: cushort
     hsyncstart*: cushort
@@ -121,12 +121,12 @@ type
     c_private*: PINT32
 
   PXF86VidModeSyncRange* = ptr TXF86VidModeSyncRange
-  TXF86VidModeSyncRange*{.final.} = object 
+  TXF86VidModeSyncRange*{.final.} = object
     hi*: cfloat
     lo*: cfloat
 
   PXF86VidModeMonitor* = ptr TXF86VidModeMonitor
-  TXF86VidModeMonitor*{.final.} = object 
+  TXF86VidModeMonitor*{.final.} = object
     vendor*: cstring
     model*: cstring
     EMPTY*: cfloat
@@ -136,94 +136,94 @@ type
     vsync*: PXF86VidModeSyncRange
 
   PXF86VidModeNotifyEvent* = ptr TXF86VidModeNotifyEvent
-  TXF86VidModeNotifyEvent*{.final.} = object 
-    theType*: cint            # of event 
-    serial*: culong           # # of last request processed by server 
-    send_event*: TBool        # true if this came from a SendEvent req 
-    display*: PDisplay        # Display the event was read from 
-    root*: TWindow            # root window of event screen 
-    state*: cint              # What happened 
-    kind*: cint               # What happened 
-    forced*: TBool            # extents of new region 
-    time*: TTime              # event timestamp 
-  
-  PXF86VidModeGamma* = ptr TXF86VidModeGamma
-  TXF86VidModeGamma*{.final.} = object 
-    red*: cfloat              # Red Gamma value 
-    green*: cfloat            # Green Gamma value 
-    blue*: cfloat             # Blue Gamma value 
-  
+  TXF86VidModeNotifyEvent*{.final.} = object
+    theType*: cint            # of event
+    serial*: culong           # # of last request processed by server
+    send_event*: TBool        # true if this came from a SendEvent req
+    display*: PDisplay        # Display the event was read from
+    root*: TWindow            # root window of event screen
+    state*: cint              # What happened
+    kind*: cint               # What happened
+    forced*: TBool            # extents of new region
+    time*: TTime              # event timestamp
 
-when defined(MACROS): 
+  PXF86VidModeGamma* = ptr TXF86VidModeGamma
+  TXF86VidModeGamma*{.final.} = object
+    red*: cfloat              # Red Gamma value
+    green*: cfloat            # Green Gamma value
+    blue*: cfloat             # Blue Gamma value
+
+
+when defined(MACROS):
   proc XF86VidModeSelectNextMode*(disp: PDisplay, scr: cint): TBool
   proc XF86VidModeSelectPrevMode*(disp: PDisplay, scr: cint): TBool
-proc XF86VidModeQueryVersion*(dpy: PDisplay, majorVersion: Pcint, 
-                              minorVersion: Pcint): TBool{.CDecl, 
+proc XF86VidModeQueryVersion*(dpy: PDisplay, majorVersion: Pcint,
+                              minorVersion: Pcint): TBool{.cdecl,
     dynlib: libXxf86vm, importc.}
-proc XF86VidModeQueryExtension*(dpy: PDisplay, event_base: Pcint, 
-                                error_base: Pcint): TBool{.CDecl, 
+proc XF86VidModeQueryExtension*(dpy: PDisplay, event_base: Pcint,
+                                error_base: Pcint): TBool{.cdecl,
     dynlib: libXxf86vm, importc.}
-proc XF86VidModeSetClientVersion*(dpy: PDisplay): TBool{.CDecl, 
+proc XF86VidModeSetClientVersion*(dpy: PDisplay): TBool{.cdecl,
     dynlib: libXxf86vm, importc.}
-proc XF86VidModeGetModeLine*(dpy: PDisplay, screen: cint, dotclock: Pcint, 
-                             modeline: PXF86VidModeModeLine): TBool{.CDecl, 
+proc XF86VidModeGetModeLine*(dpy: PDisplay, screen: cint, dotclock: Pcint,
+                             modeline: PXF86VidModeModeLine): TBool{.cdecl,
     dynlib: libXxf86vm, importc.}
-proc XF86VidModeGetAllModeLines*(dpy: PDisplay, screen: cint, modecount: Pcint, 
+proc XF86VidModeGetAllModeLines*(dpy: PDisplay, screen: cint, modecount: Pcint,
                                  modelinesPtr: PPPXF86VidModeModeInfo): TBool{.
-    CDecl, dynlib: libXxf86vm, importc.}
-proc XF86VidModeAddModeLine*(dpy: PDisplay, screen: cint, 
-                             new_modeline: PXF86VidModeModeInfo, 
+    cdecl, dynlib: libXxf86vm, importc.}
+proc XF86VidModeAddModeLine*(dpy: PDisplay, screen: cint,
+                             new_modeline: PXF86VidModeModeInfo,
                              after_modeline: PXF86VidModeModeInfo): TBool{.
-    CDecl, dynlib: libXxf86vm, importc.}
-proc XF86VidModeDeleteModeLine*(dpy: PDisplay, screen: cint, 
-                                modeline: PXF86VidModeModeInfo): TBool{.CDecl, 
+    cdecl, dynlib: libXxf86vm, importc.}
+proc XF86VidModeDeleteModeLine*(dpy: PDisplay, screen: cint,
+                                modeline: PXF86VidModeModeInfo): TBool{.cdecl,
     dynlib: libXxf86vm, importc.}
-proc XF86VidModeModModeLine*(dpy: PDisplay, screen: cint, 
-                             modeline: PXF86VidModeModeLine): TBool{.CDecl, 
+proc XF86VidModeModModeLine*(dpy: PDisplay, screen: cint,
+                             modeline: PXF86VidModeModeLine): TBool{.cdecl,
     dynlib: libXxf86vm, importc.}
-proc XF86VidModeValidateModeLine*(dpy: PDisplay, screen: cint, 
+proc XF86VidModeValidateModeLine*(dpy: PDisplay, screen: cint,
                                   modeline: PXF86VidModeModeInfo): TStatus{.
-    CDecl, dynlib: libXxf86vm, importc.}
+    cdecl, dynlib: libXxf86vm, importc.}
 proc XF86VidModeSwitchMode*(dpy: PDisplay, screen: cint, zoom: cint): TBool{.
-    CDecl, dynlib: libXxf86vm, importc.}
-proc XF86VidModeSwitchToMode*(dpy: PDisplay, screen: cint, 
-                              modeline: PXF86VidModeModeInfo): TBool{.CDecl, 
+    cdecl, dynlib: libXxf86vm, importc.}
+proc XF86VidModeSwitchToMode*(dpy: PDisplay, screen: cint,
+                              modeline: PXF86VidModeModeInfo): TBool{.cdecl,
     dynlib: libXxf86vm, importc.}
 proc XF86VidModeLockModeSwitch*(dpy: PDisplay, screen: cint, lock: cint): TBool{.
-    CDecl, dynlib: libXxf86vm, importc.}
-proc XF86VidModeGetMonitor*(dpy: PDisplay, screen: cint, 
-                            monitor: PXF86VidModeMonitor): TBool{.CDecl, 
+    cdecl, dynlib: libXxf86vm, importc.}
+proc XF86VidModeGetMonitor*(dpy: PDisplay, screen: cint,
+                            monitor: PXF86VidModeMonitor): TBool{.cdecl,
     dynlib: libXxf86vm, importc.}
-proc XF86VidModeGetViewPort*(dpy: PDisplay, screen: cint, x_return: Pcint, 
-                             y_return: Pcint): TBool{.CDecl, dynlib: libXxf86vm, 
+proc XF86VidModeGetViewPort*(dpy: PDisplay, screen: cint, x_return: Pcint,
+                             y_return: Pcint): TBool{.cdecl, dynlib: libXxf86vm,
     importc.}
 proc XF86VidModeSetViewPort*(dpy: PDisplay, screen: cint, x: cint, y: cint): TBool{.
-    CDecl, dynlib: libXxf86vm, importc.}
-proc XF86VidModeGetDotClocks*(dpy: PDisplay, screen: cint, flags_return: Pcint, 
-                              number_of_clocks_return: Pcint, 
+    cdecl, dynlib: libXxf86vm, importc.}
+proc XF86VidModeGetDotClocks*(dpy: PDisplay, screen: cint, flags_return: Pcint,
+                              number_of_clocks_return: Pcint,
                               max_dot_clock_return: Pcint, clocks_return: PPcint): TBool{.
-    CDecl, dynlib: libXxf86vm, importc.}
+    cdecl, dynlib: libXxf86vm, importc.}
 proc XF86VidModeGetGamma*(dpy: PDisplay, screen: cint, Gamma: PXF86VidModeGamma): TBool{.
-    CDecl, dynlib: libXxf86vm, importc.}
+    cdecl, dynlib: libXxf86vm, importc.}
 proc XF86VidModeSetGamma*(dpy: PDisplay, screen: cint, Gamma: PXF86VidModeGamma): TBool{.
-    CDecl, dynlib: libXxf86vm, importc.}
-proc XF86VidModeSetGammaRamp*(dpy: PDisplay, screen: cint, size: cint, 
-                              red_array: Pcushort, green_array: Pcushort, 
-                              blue_array: Pcushort): TBool{.CDecl, 
+    cdecl, dynlib: libXxf86vm, importc.}
+proc XF86VidModeSetGammaRamp*(dpy: PDisplay, screen: cint, size: cint,
+                              red_array: Pcushort, green_array: Pcushort,
+                              blue_array: Pcushort): TBool{.cdecl,
     dynlib: libXxf86vm, importc.}
-proc XF86VidModeGetGammaRamp*(dpy: PDisplay, screen: cint, size: cint, 
-                              red_array: Pcushort, green_array: Pcushort, 
-                              blue_array: Pcushort): TBool{.CDecl, 
+proc XF86VidModeGetGammaRamp*(dpy: PDisplay, screen: cint, size: cint,
+                              red_array: Pcushort, green_array: Pcushort,
+                              blue_array: Pcushort): TBool{.cdecl,
     dynlib: libXxf86vm, importc.}
 proc XF86VidModeGetGammaRampSize*(dpy: PDisplay, screen: cint, size: Pcint): TBool{.
-    CDecl, dynlib: libXxf86vm, importc.}
+    cdecl, dynlib: libXxf86vm, importc.}
 proc XF86VidModeGetPermissions*(dpy: PDisplay, screen: cint, permissions: Pcint): TBool{.
-    CDecl, dynlib: libXxf86vm, importc.}
+    cdecl, dynlib: libXxf86vm, importc.}
 # implementation
 
-#when defined(MACROS): 
-proc XF86VidModeSelectNextMode(disp: PDisplay, scr: cint): TBool = 
+#when defined(MACROS):
+proc XF86VidModeSelectNextMode(disp: PDisplay, scr: cint): TBool =
   XF86VidModeSwitchMode(disp, scr, 1)
 
-proc XF86VidModeSelectPrevMode(disp: PDisplay, scr: cint): TBool = 
+proc XF86VidModeSelectPrevMode(disp: PDisplay, scr: cint): TBool =
   XF86VidModeSwitchMode(disp, scr, - 1)

--- a/src/xkb.nim
+++ b/src/xkb.nim
@@ -68,22 +68,22 @@
 #        2004/09/15 - 16      - Convertion from the c header of XKB.h.
 #
 
-import 
+import
   X, Xlib
 
 include "x11pragma.nim"
 
-proc XkbCharToInt*(v: int8): int16
-proc XkbIntTo2Chars*(i: int16, h, L: var int8)
-proc Xkb2CharsToInt*(h, L: int8): int16
+proc XkbcharToInt*(v: int8): int16
+proc XkbIntTo2chars*(i: int16, h, L: var int8)
+proc Xkb2charsToInt*(h, L: int8): int16
   #
   #          Common data structures and access macros
-  #        
+  #
 type
   PWord* = ptr array[0..64_000, int16]
   PByte* = ptr byte
   PXkbStatePtr* = ptr TXkbStateRec
-  TXkbStateRec*{.final.} = object 
+  TXkbStateRec*{.final.} = object
     group*: int8
     locked_group*: int8
     base_group*: int16
@@ -106,25 +106,25 @@ proc XkbGroupLock*(s: PXkbStatePtr): int8
 proc XkbStateGroup*(s: PXkbStatePtr): int16
 proc XkbStateFieldFromRec*(s: PXkbStatePtr): int
 proc XkbGrabStateFromRec*(s: PXkbStatePtr): int
-type 
+type
   PXkbModsPtr* = ptr TXkbModsRec
-  TXkbModsRec*{.final.} = object 
+  TXkbModsRec*{.final.} = object
     mask*: int8               # effective mods
     real_mods*: int8
     vmods*: int16
 
 
-type 
+type
   PXkbKTMapEntryPtr* = ptr TXkbKTMapEntryRec
-  TXkbKTMapEntryRec*{.final.} = object 
+  TXkbKTMapEntryRec*{.final.} = object
     active*: bool
     level*: int8
     mods*: TXkbModsRec
 
 
-type 
+type
   PXkbKeyTypePtr* = ptr TXkbKeyTypeRec
-  TXkbKeyTypeRec*{.final.} = object 
+  TXkbKeyTypeRec*{.final.} = object
     mods*: TXkbModsRec
     num_levels*: int8
     map_count*: int8
@@ -142,17 +142,17 @@ proc XkbSetGroupInfo*(g, w, n: int16): int16
 proc XkbSetNumGroups*(g, n: int16): int16
   #
   #          Structures and access macros used primarily by the server
-  #        
-type 
+  #
+type
   PXkbBehavior* = ptr TXkbBehavior
-  TXkbBehavior*{.final.} = object 
+  TXkbBehavior*{.final.} = object
     theType*: int8
     data*: int8
 
 
-type 
+type
   PXkbModAction* = ptr TXkbModAction
-  TXkbModAction*{.final.} = object 
+  TXkbModAction*{.final.} = object
     theType*: int8
     flags*: int8
     mask*: int8
@@ -163,9 +163,9 @@ type
 
 proc XkbModActionVMods*(a: PXkbModAction): int16
 proc XkbSetModActionVMods*(a: PXkbModAction, v: int8)
-type 
+type
   PXkbGroupAction* = ptr TXkbGroupAction
-  TXkbGroupAction*{.final.} = object 
+  TXkbGroupAction*{.final.} = object
     theType*: int8
     flags*: int8
     group_XXX*: int8
@@ -173,9 +173,9 @@ type
 
 proc XkbSAGroup*(a: PXkbGroupAction): int8
 proc XkbSASetGroupProc*(a: PXkbGroupAction, g: int8)
-type 
+type
   PXkbISOAction* = ptr TXkbISOAction
-  TXkbISOAction*{.final.} = object 
+  TXkbISOAction*{.final.} = object
     theType*: int8
     flags*: int8
     mask*: int8
@@ -186,9 +186,9 @@ type
     vmods2*: int8
 
 
-type 
+type
   PXkbPtrAction* = ptr TXkbPtrAction
-  TXkbPtrAction*{.final.} = object 
+  TXkbPtrAction*{.final.} = object
     theType*: int8
     flags*: int8
     high_XXX*: int8
@@ -201,18 +201,18 @@ proc XkbPtrActionX*(a: PXkbPtrAction): int16
 proc XkbPtrActionY*(a: PXkbPtrAction): int16
 proc XkbSetPtrActionX*(a: PXkbPtrAction, x: int8)
 proc XkbSetPtrActionY*(a: PXkbPtrAction, y: int8)
-type 
+type
   PXkbPtrBtnAction* = ptr TXkbPtrBtnAction
-  TXkbPtrBtnAction*{.final.} = object 
+  TXkbPtrBtnAction*{.final.} = object
     theType*: int8
     flags*: int8
     count*: int8
     button*: int8
 
 
-type 
+type
   PXkbPtrDfltAction* = ptr TXkbPtrDfltAction
-  TXkbPtrDfltAction*{.final.} = object 
+  TXkbPtrDfltAction*{.final.} = object
     theType*: int8
     flags*: int8
     affect*: int8
@@ -221,9 +221,9 @@ type
 
 proc XkbSAPtrDfltValue*(a: PXkbPtrDfltAction): int8
 proc XkbSASetPtrDfltValue*(a: PXkbPtrDfltAction, c: pointer)
-type 
+type
   PXkbSwitchScreenAction* = ptr TXkbSwitchScreenAction
-  TXkbSwitchScreenAction*{.final.} = object 
+  TXkbSwitchScreenAction*{.final.} = object
     theType*: int8
     flags*: int8
     screenXXX*: int8
@@ -231,9 +231,9 @@ type
 
 proc XkbSAScreen*(a: PXkbSwitchScreenAction): int8
 proc XkbSASetScreen*(a: PXkbSwitchScreenAction, s: pointer)
-type 
+type
   PXkbCtrlsAction* = ptr TXkbCtrlsAction
-  TXkbCtrlsAction*{.final.} = object 
+  TXkbCtrlsAction*{.final.} = object
     theType*: int8
     flags*: int8
     ctrls3*: int8
@@ -244,17 +244,17 @@ type
 
 proc XkbActionSetCtrls*(a: PXkbCtrlsAction, c: int8)
 proc XkbActionCtrls*(a: PXkbCtrlsAction): int16
-type 
+type
   PXkbMessageAction* = ptr TXkbMessageAction
-  TXkbMessageAction*{.final.} = object 
+  TXkbMessageAction*{.final.} = object
     theType*: int8
     flags*: int8
     message*: array[0..5, char]
 
 
-type 
+type
   PXkbRedirectKeyAction* = ptr TXkbRedirectKeyAction
-  TXkbRedirectKeyAction*{.final.} = object 
+  TXkbRedirectKeyAction*{.final.} = object
     theType*: int8
     new_key*: int8
     mods_mask*: int8
@@ -269,9 +269,9 @@ proc XkbSARedirectVMods*(a: PXkbRedirectKeyAction): int16
 proc XkbSARedirectSetVMods*(a: PXkbRedirectKeyAction, m: int8)
 proc XkbSARedirectVModsMask*(a: PXkbRedirectKeyAction): int16
 proc XkbSARedirectSetVModsMask*(a: PXkbRedirectKeyAction, m: int8)
-type 
+type
   PXkbDeviceBtnAction* = ptr TXkbDeviceBtnAction
-  TXkbDeviceBtnAction*{.final.} = object 
+  TXkbDeviceBtnAction*{.final.} = object
     theType*: int8
     flags*: int8
     count*: int8
@@ -279,11 +279,11 @@ type
     device*: int8
 
 
-type 
+type
   PXkbDeviceValuatorAction* = ptr TXkbDeviceValuatorAction
   TXkbDeviceValuatorAction*{.final.} = object  #
                                                #      Macros to classify key actions
-                                               #                
+                                               #
     theType*: int8
     device*: int8
     v1_what*: int8
@@ -294,12 +294,12 @@ type
     v2_value*: int8
 
 
-const 
+const
   XkbAnyActionDataSize* = 7
 
-type 
+type
   PXkbAnyAction* = ptr TXkbAnyAction
-  TXkbAnyAction*{.final.} = object 
+  TXkbAnyAction*{.final.} = object
     theType*: int8
     data*: array[0..XkbAnyActionDataSize - 1, int8]
 
@@ -307,13 +307,13 @@ type
 proc XkbIsModAction*(a: PXkbAnyAction): bool
 proc XkbIsGroupAction*(a: PXkbAnyAction): bool
 proc XkbIsPtrAction*(a: PXkbAnyAction): bool
-type 
+type
   PXkbAction* = ptr TXkbAction
   TXkbAction*{.final.} = object  #
                                  #      XKB request codes, used in:
                                  #      -  xkbReqType field of all requests
                                  #      -  requestMinor field of some events
-                                 #                
+                                 #
     any*: TXkbAnyAction
     mods*: TXkbModAction
     group*: TXkbGroupAction
@@ -330,7 +330,7 @@ type
     theType*: int8
 
 
-const 
+const
   X_kbUseExtension* = 0
   X_kbSelectEvents* = 1
   X_kbBell* = 3
@@ -359,9 +359,9 @@ const
   X_kbSetDebuggingFlags* = 101 #
                                #      In the X sense, XKB reports only one event.
                                #      The type field of all XKB events is XkbEventCode
-                               #                
+                               #
 
-const 
+const
   XkbEventCode* = 0
   XkbNumberEvents* = XkbEventCode + 1 #
                                       #      XKB has a minor event code so it can use one X event code for
@@ -369,9 +369,9 @@ const
                                       #       - reported in the xkbType field of all XKB events.
                                       #       - XkbSelectEventDetails: Indicates the event for which event details
                                       #         are being changed
-                                      #                
+                                      #
 
-const 
+const
   XkbNewKeyboardNotify* = 0
   XkbMapNotify* = 1
   XkbStateNotify* = 2
@@ -386,9 +386,9 @@ const
   XkbExtensionDeviceNotify* = 11 #
                                  #      Event Mask:
                                  #       - XkbSelectEvents:  Specifies event interest.
-                                 #    
+                                 #
 
-const 
+const
   XkbNewKeyboardNotifyMask* = int(1) shl 0
   XkbMapNotifyMask* = int(1) shl 1
   XkbStateNotifyMask* = int(1) shl 2
@@ -403,9 +403,9 @@ const
   XkbExtensionDeviceNotifyMask* = int(1) shl 11
   XkbAllEventsMask* = 0x00000FFF #
                                  #      NewKeyboardNotify event details:
-                                 #    
+                                 #
 
-const 
+const
   XkbNKN_KeycodesMask* = int(1) shl 0
   XkbNKN_GeometryMask* = int(1) shl 1
   XkbNKN_DeviceIDMask* = int(1) shl 2
@@ -413,9 +413,9 @@ const
                                             #      AccessXNotify event types:
                                             #       - The 'what' field of AccessXNotify events reports the
                                             #         reason that the event was generated.
-                                            #                
+                                            #
 
-const 
+const
   XkbAXN_SKPress* = 0
   XkbAXN_SKAccept* = 1
   XkbAXN_SKReject* = 2
@@ -426,9 +426,9 @@ const
                          #      AccessXNotify details:
                          #      - Used as an event detail mask to limit the conditions under which
                          #        AccessXNotify events are reported
-                         #                
+                         #
 
-const 
+const
   XkbAXN_SKPressMask* = int(1) shl 0
   XkbAXN_SKAcceptMask* = int(1) shl 1
   XkbAXN_SKRejectMask* = int(1) shl 2
@@ -442,9 +442,9 @@ const
                                         #         the keyboard state components have changed.
                                         #       - Used as an event detail mask to limit the conditions under
                                         #         which StateNotify events are reported.
-                                        #                
+                                        #
 
-const 
+const
   XkbModifierStateMask* = int(1) shl 0
   XkbModifierBaseMask* = int(1) shl 1
   XkbModifierLatchMask* = int(1) shl 2
@@ -486,9 +486,9 @@ const
                                           #         that drive the indicator.
                                           #       - Specifies the boolean controls affected by the SetControls and
                                           #         LockControls key actions.
-                                          #                
+                                          #
 
-const 
+const
   XkbRepeatKeysMask* = int(1) shl 0
   XkbSlowKeysMask* = int(1) shl 1
   XkbBounceKeysMask* = int(1) shl 2
@@ -512,16 +512,16 @@ const
   XkbAllControlsMask* = 0xF8001FFF #
                                    #      Compatibility Map Compontents:
                                    #       - Specifies the components to be allocated in XkbAllocCompatMap.
-                                   #                
+                                   #
 
-const 
+const
   XkbSymInterpMask* = 1 shl 0
   XkbGroupCompatMask* = 1 shl 1
   XkbAllCompatMask* = 0x00000003 #
                                  #      Assorted constants and limits.
-                                 #                
+                                 #
 
-const 
+const
   XkbAllIndicatorsMask* = 0xFFFFFFFF #
                                      #      Map components masks:
                                      #      Those in AllMapComponentsMask:
@@ -531,9 +531,9 @@ const
                                      #       - Specifies the components to be allocated by XkbAllocClientMap.
                                      #      Those in ServerInfoMask:
                                      #       - Specifies the components to be allocated by XkbAllocServerMap.
-                                     #                
+                                     #
 
-const 
+const
   XkbKeyTypesMask* = 1 shl 0
   XkbKeySymsMask* = 1 shl 1
   XkbModifierMapMask* = 1 shl 2
@@ -552,9 +552,9 @@ const
                                                                           #         SetNames requests.
                                                                           #       - Specifies the names that have changed in a NamesNotify event.
                                                                           #       - Specifies the names components to be allocated by XkbAllocNames.
-                                                                          #                
+                                                                          #
 
-const 
+const
   XkbKeycodesNameMask* = 1 shl 0
   XkbGeometryNameMask* = 1 shl 1
   XkbSymbolsNameMask* = 1 shl 2
@@ -574,9 +574,9 @@ const
                                 #      Miscellaneous event details:
                                 #      - event detail masks for assorted events that don't reall
                                 #        have any details.
-                                #                
+                                #
 
-const 
+const
   XkbAllStateEventsMask* = XkbAllStateComponentsMask
   XkbAllMapEventsMask* = XkbAllMapComponentsMask
   XkbAllControlEventsMask* = XkbAllControlsMask
@@ -596,9 +596,9 @@ const
                                            #                            found.
                                            #      The low byte of the resourceID for this error contains the device
                                            #      id, class specifier or feedback id that failed.
-                                           #                
+                                           #
 
-const 
+const
   XkbKeyboard* = 0
   XkbNumberErrors* = 1
   XkbErr_BadDevice* = 0x000000FF
@@ -606,9 +606,9 @@ const
   XkbErr_BadId* = 0x000000FD #
                              #      Keyboard Components Mask:
                              #      - Specifies the components that follow a GetKeyboardByNameReply
-                             #                
+                             #
 
-const 
+const
   XkbClientMapMask* = int(1) shl 0
   XkbServerMapMask* = int(1) shl 1
   XkbCompatMapMask* = int(1) shl 2
@@ -624,9 +624,9 @@ const
                                      #         fields of an XkbControlsRec specify the Access X options to be
                                      #         changed if the keyboard times out and the values to which they
                                      #         should be changed.
-                                     #                
+                                     #
 
-const 
+const
   XkbAX_SKPressFBMask* = int(1) shl 0
   XkbAX_SKAcceptFBMask* = int(1) shl 1
   XkbAX_FeatureFBMask* = int(1) shl 2
@@ -667,9 +667,9 @@ const
                                      #                             including the default.
                                      #      XkbSingleXIId(i)       True if 'i' specifies exactly one device
                                      #                              identifier, including the default.
-                                     #                
+                                     #
 
-const 
+const
   XkbUseCoreKbd* = 0x00000100
   XkbUseCorePtr* = 0x00000200
   XkbDfltXIClass* = 0x00000300
@@ -685,7 +685,7 @@ proc XkbExplicitXIClass*(c: int): bool
 proc XkbExplicitXIId*(c: int): bool
 proc XkbSingleXIClass*(c: int): bool
 proc XkbSingleXIId*(c: int): bool
-const 
+const
   XkbNoModifier* = 0x000000FF
   XkbNoShiftLevel* = 0x000000FF
   XkbNoShape* = 0x000000FF
@@ -699,9 +699,9 @@ const
                           #      Group Index and Mask:
                           #       - Indices into the kt_index array of a key type.
                           #       - Mask specifies types to be changed for XkbChangeTypesOfKey
-                          #    
+                          #
 
-const 
+const
   XkbGroup1Index* = 0
   XkbGroup2Index* = 1
   XkbGroup3Index* = 2
@@ -719,7 +719,7 @@ const
                                  #      GroupForCoreState:  Given the state reported in an event,
                                  #                      determine the keyboard group.
                                  #      IsLegalGroup:   Returns TRUE if 'g' is a valid group index.
-                                 #                
+                                 #
 
 proc XkbBuildCoreState*(m, g: int): int
 proc XkbGroupForCoreState*(s: int): int
@@ -731,8 +731,8 @@ proc XkbIsLegalGroup*(g: int): bool
   #       - Bits 6 and 7 of the group info field of a key symbol map
   #         specify the interpretation of out of range groups for the
   #         corresponding key.
-  #                
-const 
+  #
+const
   XkbWrapIntoRange* = 0x00000000
   XkbClampIntoRange* = 0x00000040
   XkbRedirectIntoRange* = 0x00000080 #
@@ -764,9 +764,9 @@ const
                                      #      DfltBtnAbsolute           SetPtrDflt
                                      #      SwitchApplication SwitchScreen
                                      #      SwitchAbsolute            SwitchScreen
-                                     #                
+                                     #
 
-const 
+const
   XkbSA_ClearLocks* = int(1) shl 0
   XkbSA_LatchToLock* = int(1) shl 1
   XkbSA_LockNoLock* = int(1) shl 0
@@ -794,9 +794,9 @@ const
                                        #      action only.  Valuator operations specify the action
                                        #      to be taken.   Values specified in the action are
                                        #      multiplied by 2^scale before they are applied.
-                                       #                
+                                       #
 
-const 
+const
   XkbSA_IgnoreVal* = 0x00000000
   XkbSA_SetValMin* = 0x00000010
   XkbSA_SetValCenter* = 0x00000020
@@ -811,8 +811,8 @@ proc XkbSA_ValScale*(a: int): int
   #
   #      Action types: specifies the type of a key action.  Reported in the
   #      type field of all key actions.
-  #                
-const 
+  #
+const
   XkbSA_NoAction* = 0x00000000
   XkbSA_SetMods* = 0x00000001
   XkbSA_LatchMods* = 0x00000002
@@ -837,11 +837,11 @@ const
   XkbSA_LastAction* = XkbSA_DeviceValuator
   XkbSA_NumActions* = XkbSA_LastAction + 1
 
-const 
+const
   XkbSA_XFree86Private* = 0x00000086
 #
 #      Specifies the key actions that clear latched groups or modifiers.
-#                
+#
 
 const  ##define        XkbSA_BreakLatch \
        #        ((1<<XkbSA_NoAction)|(1<<XkbSA_PtrBtn)|(1<<XkbSA_LockPtrBtn)|\
@@ -860,9 +860,9 @@ const  ##define        XkbSA_BreakLatch \
                                                              #         the listed behavior.
                                                              #      Key Behavior Types:
                                                              #         Specifies the behavior of the underlying key.
-                                                             #                
+                                                             #
 
-const 
+const
   XkbKB_Permanent* = 0x00000080
   XkbKB_OpMask* = 0x0000007F
   XkbKB_Default* = 0x00000000
@@ -872,18 +872,18 @@ const
   XkbKB_Overlay2* = 0x00000004
   XkbKB_RGAllowNone* = 0x00000080 #
                                   #      Various macros which describe the range of legal keycodes.
-                                  #                
+                                  #
 
-const 
+const
   XkbMinLegalKeyCode* = 8
   XkbMaxLegalKeyCode* = 255
   XkbMaxKeyCount* = XkbMaxLegalKeyCode - XkbMinLegalKeyCode + 1
   XkbPerKeyBitArraySize* = (XkbMaxLegalKeyCode + 1) div 8
 
 proc XkbIsLegalKeycode*(k: int): bool
-type 
+type
   PXkbControlsPtr* = ptr TXkbControlsRec
-  TXkbControlsRec*{.final.} = object 
+  TXkbControlsRec*{.final.} = object
     mk_dflt_btn*: int8
     num_groups*: int8
     groups_wrap*: int8
@@ -913,8 +913,8 @@ proc XkbAX_NeedOption*(c: PXkbControlsPtr, w: int16): int16
 proc XkbAX_NeedFeedback*(c: PXkbControlsPtr, w: int16): bool
   #
   #      Assorted constants and limits.
-  #                
-const 
+  #
+const
   XkbNumModifiers* = 8
   XkbNumVirtualMods* = 16
   XkbNumIndicators* = 32
@@ -931,9 +931,9 @@ const
   XkbGeomMaxLabelColors* = 3
   XkbGeomMaxPriority* = 255
 
-type 
+type
   PXkbServerMapPtr* = ptr TXkbServerMapRec
-  TXkbServerMapRec*{.final.} = object 
+  TXkbServerMapRec*{.final.} = object
     num_acts*: int16
     size_acts*: int16
     acts*: ptr array[0..0xfff, TXkbAction]
@@ -947,19 +947,19 @@ type
 proc XkbSMKeyActionsPtr*(m: PXkbServerMapPtr, k: int16): PXkbAction
   #
   #          Structures and access macros used primarily by clients
-  #        
-type 
+  #
+type
   PXkbSymMapPtr* = ptr TXkbSymMapRec
-  TXkbSymMapRec*{.final.} = object 
+  TXkbSymMapRec*{.final.} = object
     kt_index*: array[0..XkbNumKbdGroups - 1, int8]
     group_info*: int8
     width*: int8
     offset*: int8
 
 
-type 
+type
   PXkbClientMapPtr* = ptr TXkbClientMapRec
-  TXkbClientMapRec*{.final.} = object 
+  TXkbClientMapRec*{.final.} = object
     size_types*: int8
     num_types*: int8
     types*: ptr array[0..0xffff, TXkbKeyTypeRec]
@@ -980,10 +980,10 @@ proc XkbCMKeyNumSyms*(m: PXkbClientMapPtr, k: int16): int16
 proc XkbCMKeySymsOffset*(m: PXkbClientMapPtr, k: int16): int8
   #
   #          Compatibility structures and access macros
-  #        
-type 
+  #
+type
   PXkbSymInterpretPtr* = ptr TXkbSymInterpretRec
-  TXkbSymInterpretRec*{.final.} = object 
+  TXkbSymInterpretRec*{.final.} = object
     sym*: TKeySym
     flags*: int8
     match*: int8
@@ -992,18 +992,18 @@ type
     act*: TXkbAnyAction
 
 
-type 
+type
   PXkbCompatMapPtr* = ptr TXkbCompatMapRec
-  TXkbCompatMapRec*{.final.} = object 
+  TXkbCompatMapRec*{.final.} = object
     sym_interpret*: PXkbSymInterpretPtr
     groups*: array[0..XkbNumKbdGroups - 1, TXkbModsRec]
     num_si*: int16
     size_si*: int16
 
 
-type 
+type
   PXkbIndicatorMapPtr* = ptr TXkbIndicatorMapRec
-  TXkbIndicatorMapRec*{.final.} = object 
+  TXkbIndicatorMapRec*{.final.} = object
     flags*: int8
     which_groups*: int8
     groups*: int8
@@ -1014,33 +1014,33 @@ type
 
 proc XkbIM_IsAuto*(i: PXkbIndicatorMapPtr): bool
 proc XkbIM_InUse*(i: PXkbIndicatorMapPtr): bool
-type 
+type
   PXkbIndicatorPtr* = ptr TXkbIndicatorRec
-  TXkbIndicatorRec*{.final.} = object 
+  TXkbIndicatorRec*{.final.} = object
     phys_indicators*: int32
     maps*: array[0..XkbNumIndicators - 1, TXkbIndicatorMapRec]
 
 
-type 
+type
   PXkbKeyNamePtr* = ptr TXkbKeyNameRec
-  TXkbKeyNameRec*{.final.} = object 
-    name*: array[0..XkbKeyNameLength - 1, Char]
+  TXkbKeyNameRec*{.final.} = object
+    name*: array[0..XkbKeyNameLength - 1, char]
 
 
-type 
+type
   PXkbKeyAliasPtr* = ptr TXkbKeyAliasRec
   TXkbKeyAliasRec*{.final.} = object  #
                                       #          Names for everything
-                                      #        
-    float*: array[0..XkbKeyNameLength - 1, Char]
-    alias*: array[0..XkbKeyNameLength - 1, Char]
+                                      #
+    float*: array[0..XkbKeyNameLength - 1, char]
+    alias*: array[0..XkbKeyNameLength - 1, char]
 
 
-type 
+type
   PXkbNamesPtr* = ptr TXkbNamesRec
   TXkbNamesRec*{.final.} = object  #
                                    #      Key Type index and mask for the four standard key types.
-                                   #                
+                                   #
     keycodes*: TAtom
     geometry*: TAtom
     symbols*: TAtom
@@ -1058,7 +1058,7 @@ type
     num_rg*: int16
 
 
-const 
+const
   XkbOneLevelIndex* = 0
   XkbTwoLevelIndex* = 1
   XkbAlphabeticIndex* = 2
@@ -1076,8 +1076,8 @@ proc XkbShiftLevel*(n: int8): int8
 proc XkbShiftLevelMask*(n: int8): int8
   #
   #      Extension name and version information
-  #                
-const 
+  #
+const
   XkbName* = "XKEYBOARD"
   XkbMajorVersion* = 1
   XkbMinorVersion* = 0 #
@@ -1085,9 +1085,9 @@ const
                        #       - Used in the 'explicit' field of an XkbServerMap.  Specifies
                        #         the keyboard components that should _not_ be updated automatically
                        #         in response to core protocol keyboard mapping requests.
-                       #                
+                       #
 
-const 
+const
   XkbExplicitKeyTypesMask* = 0x0000000F
   XkbExplicitKeyType1Mask* = 1 shl 0
   XkbExplicitKeyType2Mask* = 1 shl 1
@@ -1100,17 +1100,17 @@ const
   XkbAllExplicitMask* = 0x000000FF #
                                    #      Symbol interpretations flags:
                                    #       - Used in the flags field of a symbol interpretation
-                                   #                
+                                   #
 
-const 
+const
   XkbSI_AutoRepeat* = 1 shl 0
   XkbSI_LockingKey* = 1 shl 1 #
                               #      Symbol interpretations match specification:
                               #       - Used in the match field of a symbol interpretation to specify
                               #         the conditions under which an interpretation is used.
-                              #                
+                              #
 
-const 
+const
   XkbSI_LevelOneOnly* = 0x00000080
   XkbSI_OpMask* = 0x0000007F
   XkbSI_NoneOf* = 0
@@ -1122,9 +1122,9 @@ const
                      #       - Used in the flags field of an indicator map to indicate the
                      #         conditions under which and indicator can be changed and the
                      #         effects of changing the indicator.
-                     #                
+                     #
 
-const 
+const
   XkbIM_NoExplicit* = int(1) shl 7
   XkbIM_NoAutomatic* = int(1) shl 6
   XkbIM_LEDDrivesKB* = int(1) shl 5 #
@@ -1132,9 +1132,9 @@ const
                                     #       - Used by the 'which_groups' and 'which_mods' fields of an indicator
                                     #         map to specify which keyboard components should be used to drive
                                     #         the indicator.
-                                    #                
+                                    #
 
-const 
+const
   XkbIM_UseBase* = int(1) shl 0
   XkbIM_UseLatched* = int(1) shl 1
   XkbIM_UseLocked* = int(1) shl 2
@@ -1147,9 +1147,9 @@ const
                                                            #      GetByName components:
                                                            #       - Specifies desired or necessary components to GetKbdByName request.
                                                            #       - Reports the components that were found in a GetKbdByNameReply
-                                                           #                
+                                                           #
 
-const 
+const
   XkbGBN_TypesMask* = int(1) shl 0
   XkbGBN_CompatMapMask* = int(1) shl 1
   XkbGBN_ClientSymbolsMask* = int(1) shl 2
@@ -1161,9 +1161,9 @@ const
   XkbGBN_OtherNamesMask* = int(1) shl 7
   XkbGBN_AllComponentsMask* = 0x000000FF #
                                          #       ListComponents flags
-                                         #                        
+                                         #
 
-const 
+const
   XkbLC_Hidden* = int(1) shl 0
   XkbLC_Default* = int(1) shl 1
   XkbLC_Partial* = int(1) shl 2
@@ -1181,9 +1181,9 @@ const
                                         #        XkbGetDeviceInfo or in an XkbExtensionDeviceNotify event.
                                         #      XkbXI_UnsupportedFeature is reported in XkbExtensionDeviceNotify
                                         #      events to indicate an attempt to use an unsupported feature.
-                                        #                
+                                        #
 
-const 
+const
   XkbXI_KeyboardsMask* = int(1) shl 0
   XkbXI_ButtonActionsMask* = int(1) shl 1
   XkbXI_IndicatorNamesMask* = int(1) shl 2
@@ -1196,9 +1196,9 @@ const
   XkbAllExtensionDeviceEventsMask* = 0x0000801F #
                                                 #      Per-Client Flags:
                                                 #       - Specifies flags to be changed by the PerClientFlags request.
-                                                #                
+                                                #
 
-const 
+const
   XkbPCF_DetectableAutoRepeatMask* = int(1) shl 0
   XkbPCF_GrabsUseXKBStateMask* = int(1) shl 1
   XkbPCF_AutoResetControlsMask* = int(1) shl 2
@@ -1206,35 +1206,35 @@ const
   XkbPCF_SendEventUsesXKBState* = int(1) shl 4
   XkbPCF_AllFlagsMask* = 0x0000001F #
                                     #      Debugging flags and controls
-                                    #                
+                                    #
 
-const 
+const
   XkbDF_DisableLocks* = 1 shl 0
 
-type 
+type
   PXkbPropertyPtr* = ptr TXkbPropertyRec
-  TXkbPropertyRec*{.final.} = object 
+  TXkbPropertyRec*{.final.} = object
     name*: cstring
     value*: cstring
 
 
-type 
+type
   PXkbColorPtr* = ptr TXkbColorRec
-  TXkbColorRec*{.final.} = object 
+  TXkbColorRec*{.final.} = object
     pixel*: int16
     spec*: cstring
 
 
-type 
+type
   PXkbPointPtr* = ptr TXkbPointRec
-  TXkbPointRec*{.final.} = object 
+  TXkbPointRec*{.final.} = object
     x*: int16
     y*: int16
 
 
-type 
+type
   PXkbBoundsPtr* = ptr TXkbBoundsRec
-  TXkbBoundsRec*{.final.} = object 
+  TXkbBoundsRec*{.final.} = object
     x1*: int16
     y1*: int16
     x2*: int16
@@ -1243,18 +1243,18 @@ type
 
 proc XkbBoundsWidth*(b: PXkbBoundsPtr): int16
 proc XkbBoundsHeight*(b: PXkbBoundsPtr): int16
-type 
+type
   PXkbOutlinePtr* = ptr TXkbOutlineRec
-  TXkbOutlineRec*{.final.} = object 
+  TXkbOutlineRec*{.final.} = object
     num_points*: int16
     sz_points*: int16
     corner_radius*: int16
     points*: PXkbPointPtr
 
 
-type 
+type
   PXkbShapePtr* = ptr TXkbShapeRec
-  TXkbShapeRec*{.final.} = object 
+  TXkbShapeRec*{.final.} = object
     name*: TAtom
     num_outlines*: int16
     sz_outlines*: int16
@@ -1265,9 +1265,9 @@ type
 
 
 proc XkbOutlineIndex*(s: PXkbShapePtr, o: PXkbOutlinePtr): int32
-type 
+type
   PXkbShapeDoodadPtr* = ptr TXkbShapeDoodadRec
-  TXkbShapeDoodadRec*{.final.} = object 
+  TXkbShapeDoodadRec*{.final.} = object
     name*: TAtom
     theType*: int8
     priority*: int8
@@ -1278,9 +1278,9 @@ type
     shape_ndx*: int16
 
 
-type 
+type
   PXkbTextDoodadPtr* = ptr TXkbTextDoodadRec
-  TXkbTextDoodadRec*{.final.} = object 
+  TXkbTextDoodadRec*{.final.} = object
     name*: TAtom
     theType*: int8
     priority*: int8
@@ -1294,9 +1294,9 @@ type
     font*: cstring
 
 
-type 
+type
   PXkbIndicatorDoodadPtr* = ptr TXkbIndicatorDoodadRec
-  TXkbIndicatorDoodadRec*{.final.} = object 
+  TXkbIndicatorDoodadRec*{.final.} = object
     name*: TAtom
     theType*: int8
     priority*: int8
@@ -1308,9 +1308,9 @@ type
     off_color_ndx*: int16
 
 
-type 
+type
   PXkbLogoDoodadPtr* = ptr TXkbLogoDoodadRec
-  TXkbLogoDoodadRec*{.final.} = object 
+  TXkbLogoDoodadRec*{.final.} = object
     name*: TAtom
     theType*: int8
     priority*: int8
@@ -1322,9 +1322,9 @@ type
     logo_name*: cstring
 
 
-type 
+type
   PXkbAnyDoodadPtr* = ptr TXkbAnyDoodadRec
-  TXkbAnyDoodadRec*{.final.} = object 
+  TXkbAnyDoodadRec*{.final.} = object
     name*: TAtom
     theType*: int8
     priority*: int8
@@ -1333,9 +1333,9 @@ type
     angle*: int16
 
 
-type 
+type
   PXkbDoodadPtr* = ptr TXkbDoodadRec
-  TXkbDoodadRec*{.final.} = object 
+  TXkbDoodadRec*{.final.} = object
     any*: TXkbAnyDoodadRec
     shape*: TXkbShapeDoodadRec
     text*: TXkbTextDoodadRec
@@ -1343,7 +1343,7 @@ type
     logo*: TXkbLogoDoodadRec
 
 
-const 
+const
   XkbUnknownDoodad* = 0
   XkbOutlineDoodad* = 1
   XkbSolidDoodad* = 2
@@ -1351,18 +1351,18 @@ const
   XkbIndicatorDoodad* = 4
   XkbLogoDoodad* = 5
 
-type 
+type
   PXkbKeyPtr* = ptr TXkbKeyRec
-  TXkbKeyRec*{.final.} = object 
+  TXkbKeyRec*{.final.} = object
     name*: TXkbKeyNameRec
     gap*: int16
     shape_ndx*: int8
     color_ndx*: int8
 
 
-type 
+type
   PXkbRowPtr* = ptr TXkbRowRec
-  TXkbRowRec*{.final.} = object 
+  TXkbRowRec*{.final.} = object
     top*: int16
     left*: int16
     num_keys*: int16
@@ -1372,7 +1372,7 @@ type
     bounds*: TXkbBoundsRec
 
 
-type 
+type
   PXkbOverlayPtr* = ptr TXkbOverlayRec #forward for TXkbSectionRec use.
                                        #Do not add more "type"
   PXkbSectionPtr* = ptr TXkbSectionRec
@@ -1404,7 +1404,7 @@ type
     sz_keys*: int16
     keys*: PXkbOverlayKeyPtr
 
-  TXkbOverlayRec*{.final.} = object 
+  TXkbOverlayRec*{.final.} = object
     name*: TAtom
     section_under*: PXkbSectionPtr
     num_rows*: int16
@@ -1413,10 +1413,10 @@ type
     bounds*: PXkbBoundsPtr
 
 
-type 
+type
   PXkbGeometryRec* = ptr TXkbGeometryRec
   PXkbGeometryPtr* = PXkbGeometryRec
-  TXkbGeometryRec*{.final.} = object 
+  TXkbGeometryRec*{.final.} = object
     name*: TAtom
     width_mm*: int16
     height_mm*: int16
@@ -1442,7 +1442,7 @@ type
     key_aliases*: ptr array[0..0xffff, TXkbKeyAliasRec]
 
 
-const 
+const
   XkbGeomPropertiesMask* = 1 shl 0
   XkbGeomColorsMask* = 1 shl 1
   XkbGeomShapesMask* = 1 shl 2
@@ -1451,11 +1451,11 @@ const
   XkbGeomKeyAliasesMask* = 1 shl 5
   XkbGeomAllMask* = 0x0000003F
 
-type 
+type
   PXkbGeometrySizesPtr* = ptr TXkbGeometrySizesRec
   TXkbGeometrySizesRec*{.final.} = object  #
                                            #          Tie it all together into one big keyboard description
-                                           #        
+                                           #
     which*: int16
     num_properties*: int16
     num_colors*: int16
@@ -1465,9 +1465,9 @@ type
     num_key_aliases*: int16
 
 
-type 
+type
   PXkbDescPtr* = ptr TXkbDescRec
-  TXkbDescRec*{.final.} = object 
+  TXkbDescRec*{.final.} = object
     dpy*: PDisplay
     flags*: int16
     device_spec*: int16
@@ -1501,10 +1501,10 @@ proc XkbNumKeys*(d: PXkbDescPtr): int8
   #
   #          The following structures can be used to track changes
   #          to a keyboard device
-  #        
-type 
+  #
+type
   PXkbMapChangesPtr* = ptr TXkbMapChangesRec
-  TXkbMapChangesRec*{.final.} = object 
+  TXkbMapChangesRec*{.final.} = object
     changed*: int16
     min_key_code*: TKeyCode
     max_key_code*: TKeyCode
@@ -1526,24 +1526,24 @@ type
     vmods*: int16
 
 
-type 
+type
   PXkbControlsChangesPtr* = ptr TXkbControlsChangesRec
-  TXkbControlsChangesRec*{.final.} = object 
+  TXkbControlsChangesRec*{.final.} = object
     changed_ctrls*: int16
     enabled_ctrls_changes*: int16
     num_groups_changed*: bool
 
 
-type 
+type
   PXkbIndicatorChangesPtr* = ptr TXkbIndicatorChangesRec
-  TXkbIndicatorChangesRec*{.final.} = object 
+  TXkbIndicatorChangesRec*{.final.} = object
     state_changes*: int16
     map_changes*: int16
 
 
-type 
+type
   PXkbNameChangesPtr* = ptr TXkbNameChangesRec
-  TXkbNameChangesRec*{.final.} = object 
+  TXkbNameChangesRec*{.final.} = object
     changed*: int16
     first_type*: int8
     num_types*: int8
@@ -1558,21 +1558,21 @@ type
     changed_groups*: int8
 
 
-type 
+type
   PXkbCompatChangesPtr* = ptr TXkbCompatChangesRec
-  TXkbCompatChangesRec*{.final.} = object 
+  TXkbCompatChangesRec*{.final.} = object
     changed_groups*: int8
     first_si*: int16
     num_si*: int16
 
 
-type 
+type
   PXkbChangesPtr* = ptr TXkbChangesRec
   TXkbChangesRec*{.final.} = object  #
                                      #          These data structures are used to construct a keymap from
                                      #          a set of components or to list components in the server
                                      #          database.
-                                     #        
+                                     #
     device_spec*: int16
     state_changes*: int16
     map*: TXkbMapChangesRec
@@ -1582,9 +1582,9 @@ type
     compat*: TXkbCompatChangesRec
 
 
-type 
+type
   PXkbComponentNamesPtr* = ptr TXkbComponentNamesRec
-  TXkbComponentNamesRec*{.final.} = object 
+  TXkbComponentNamesRec*{.final.} = object
     keymap*: ptr int16
     keycodes*: ptr int16
     types*: ptr int16
@@ -1593,19 +1593,19 @@ type
     geometry*: ptr int16
 
 
-type 
+type
   PXkbComponentNamePtr* = ptr TXkbComponentNameRec
-  TXkbComponentNameRec*{.final.} = object 
+  TXkbComponentNameRec*{.final.} = object
     flags*: int16
     name*: cstring
 
 
-type 
+type
   PXkbComponentListPtr* = ptr TXkbComponentListRec
   TXkbComponentListRec*{.final.} = object  #
                                            #          The following data structures describe and track changes to a
                                            #          non-keyboard extension device
-                                           #        
+                                           #
     num_keymaps*: int16
     num_keycodes*: int16
     num_types*: int16
@@ -1620,9 +1620,9 @@ type
     geometry*: PXkbComponentNamePtr
 
 
-type 
+type
   PXkbDeviceLedInfoPtr* = ptr TXkbDeviceLedInfoRec
-  TXkbDeviceLedInfoRec*{.final.} = object 
+  TXkbDeviceLedInfoRec*{.final.} = object
     led_class*: int16
     led_id*: int16
     phys_indicators*: int16
@@ -1633,9 +1633,9 @@ type
     maps*: array[0..XkbNumIndicators - 1, TXkbIndicatorMapRec]
 
 
-type 
+type
   PXkbDeviceInfoPtr* = ptr TXkbDeviceInfoRec
-  TXkbDeviceInfoRec*{.final.} = object 
+  TXkbDeviceInfoRec*{.final.} = object
     name*: cstring
     theType*: TAtom
     device_spec*: int16
@@ -1654,18 +1654,18 @@ type
 proc XkbXI_DevHasBtnActs*(d: PXkbDeviceInfoPtr): bool
 proc XkbXI_LegalDevBtn*(d: PXkbDeviceInfoPtr, b: int16): bool
 proc XkbXI_DevHasLeds*(d: PXkbDeviceInfoPtr): bool
-type 
+type
   PXkbDeviceLedChangesPtr* = ptr TXkbDeviceLedChangesRec
-  TXkbDeviceLedChangesRec*{.final.} = object 
+  TXkbDeviceLedChangesRec*{.final.} = object
     led_class*: int16
     led_id*: int16
     defined*: int16           #names or maps changed
     next*: PXkbDeviceLedChangesPtr
 
 
-type 
+type
   PXkbDeviceChangesPtr* = ptr TXkbDeviceChangesRec
-  TXkbDeviceChangesRec*{.final.} = object 
+  TXkbDeviceChangesRec*{.final.} = object
     changed*: int16
     first_btn*: int16
     num_btns*: int16
@@ -1674,27 +1674,27 @@ type
 
 proc XkbShapeDoodadColor*(g: PXkbGeometryPtr, d: PXkbShapeDoodadPtr): PXkbColorPtr
 proc XkbShapeDoodadShape*(g: PXkbGeometryPtr, d: PXkbShapeDoodadPtr): PXkbShapePtr
-proc XkbSetShapeDoodadColor*(g: PXkbGeometryPtr, d: PXkbShapeDoodadPtr, 
+proc XkbSetShapeDoodadColor*(g: PXkbGeometryPtr, d: PXkbShapeDoodadPtr,
                              c: PXkbColorPtr)
-proc XkbSetShapeDoodadShape*(g: PXkbGeometryPtr, d: PXkbShapeDoodadPtr, 
+proc XkbSetShapeDoodadShape*(g: PXkbGeometryPtr, d: PXkbShapeDoodadPtr,
                              s: PXkbShapePtr)
 proc XkbTextDoodadColor*(g: PXkbGeometryPtr, d: PXkbTextDoodadPtr): PXkbColorPtr
-proc XkbSetTextDoodadColor*(g: PXkbGeometryPtr, d: PXkbTextDoodadPtr, 
+proc XkbSetTextDoodadColor*(g: PXkbGeometryPtr, d: PXkbTextDoodadPtr,
                             c: PXkbColorPtr)
 proc XkbIndicatorDoodadShape*(g: PXkbGeometryPtr, d: PXkbIndicatorDoodadPtr): PXkbShapeDoodadPtr
 proc XkbIndicatorDoodadOnColor*(g: PXkbGeometryPtr, d: PXkbIndicatorDoodadPtr): PXkbColorPtr
 proc XkbIndicatorDoodadOffColor*(g: PXkbGeometryPtr, d: PXkbIndicatorDoodadPtr): PXkbColorPtr
-proc XkbSetIndicatorDoodadOnColor*(g: PXkbGeometryPtr, 
+proc XkbSetIndicatorDoodadOnColor*(g: PXkbGeometryPtr,
                                    d: PXkbIndicatorDoodadPtr, c: PXkbColorPtr)
-proc XkbSetIndicatorDoodadOffColor*(g: PXkbGeometryPtr, 
+proc XkbSetIndicatorDoodadOffColor*(g: PXkbGeometryPtr,
                                     d: PXkbIndicatorDoodadPtr, c: PXkbColorPtr)
-proc XkbSetIndicatorDoodadShape*(g: PXkbGeometryPtr, d: PXkbIndicatorDoodadPtr, 
+proc XkbSetIndicatorDoodadShape*(g: PXkbGeometryPtr, d: PXkbIndicatorDoodadPtr,
                                  s: PXkbShapeDoodadPtr)
 proc XkbLogoDoodadColor*(g: PXkbGeometryPtr, d: PXkbLogoDoodadPtr): PXkbColorPtr
 proc XkbLogoDoodadShape*(g: PXkbGeometryPtr, d: PXkbLogoDoodadPtr): PXkbShapeDoodadPtr
-proc XkbSetLogoDoodadColor*(g: PXkbGeometryPtr, d: PXkbLogoDoodadPtr, 
+proc XkbSetLogoDoodadColor*(g: PXkbGeometryPtr, d: PXkbLogoDoodadPtr,
                             c: PXkbColorPtr)
-proc XkbSetLogoDoodadShape*(g: PXkbGeometryPtr, d: PXkbLogoDoodadPtr, 
+proc XkbSetLogoDoodadShape*(g: PXkbGeometryPtr, d: PXkbLogoDoodadPtr,
                             s: PXkbShapeDoodadPtr)
 proc XkbKeyShape*(g: PXkbGeometryPtr, k: PXkbKeyPtr): PXkbShapeDoodadPtr
 proc XkbKeyColor*(g: PXkbGeometryPtr, k: PXkbKeyPtr): PXkbColorPtr
@@ -1711,57 +1711,57 @@ proc XkbAddGeomOutline*(shape: PXkbShapePtr, sz_points: int16): PXkbOutlinePtr{.
     libx11c, importc: "XkbAddGeomOutline".}
 proc XkbAddGeomShape*(geom: PXkbGeometryPtr, name: TAtom, sz_outlines: int16): PXkbShapePtr{.
     libx11c, importc: "XkbAddGeomShape".}
-proc XkbAddGeomKey*(row: PXkbRowPtr): PXkbKeyPtr{.libx11c, 
+proc XkbAddGeomKey*(row: PXkbRowPtr): PXkbKeyPtr{.libx11c,
     importc: "XkbAddGeomKey".}
 proc XkbAddGeomRow*(section: PXkbSectionPtr, sz_keys: int16): PXkbRowPtr{.libx11c, importc: "XkbAddGeomRow".}
-proc XkbAddGeomSection*(geom: PXkbGeometryPtr, name: TAtom, sz_rows: int16, 
+proc XkbAddGeomSection*(geom: PXkbGeometryPtr, name: TAtom, sz_rows: int16,
                         sz_doodads: int16, sz_overlays: int16): PXkbSectionPtr{.
     libx11c, importc: "XkbAddGeomSection".}
 proc XkbAddGeomOverlay*(section: PXkbSectionPtr, name: TAtom, sz_rows: int16): PXkbOverlayPtr{.
     libx11c, importc: "XkbAddGeomOverlay".}
-proc XkbAddGeomOverlayRow*(overlay: PXkbOverlayPtr, row_under: int16, 
+proc XkbAddGeomOverlayRow*(overlay: PXkbOverlayPtr, row_under: int16,
                            sz_keys: int16): PXkbOverlayRowPtr{.libx11c, importc: "XkbAddGeomOverlayRow".}
-proc XkbAddGeomOverlayKey*(overlay: PXkbOverlayPtr, row: PXkbOverlayRowPtr, 
+proc XkbAddGeomOverlayKey*(overlay: PXkbOverlayPtr, row: PXkbOverlayRowPtr,
                            over: cstring, under: cstring): PXkbOverlayKeyPtr{.
     libx11c, importc: "XkbAddGeomOverlayKey".}
-proc XkbAddGeomDoodad*(geom: PXkbGeometryPtr, section: PXkbSectionPtr, 
-                       name: TAtom): PXkbDoodadPtr{.libx11c, 
+proc XkbAddGeomDoodad*(geom: PXkbGeometryPtr, section: PXkbSectionPtr,
+                       name: TAtom): PXkbDoodadPtr{.libx11c,
     importc: "XkbAddGeomDoodad".}
-proc XkbFreeGeomKeyAliases*(geom: PXkbGeometryPtr, first: int16, count: int16, 
-                            freeAll: bool){.libx11c, 
+proc XkbFreeGeomKeyAliases*(geom: PXkbGeometryPtr, first: int16, count: int16,
+                            freeAll: bool){.libx11c,
     importc: "XkbFreeGeomKeyAliases".}
-proc XkbFreeGeomColors*(geom: PXkbGeometryPtr, first: int16, count: int16, 
-                        freeAll: bool){.libx11c, 
+proc XkbFreeGeomColors*(geom: PXkbGeometryPtr, first: int16, count: int16,
+                        freeAll: bool){.libx11c,
                                         importc: "XkbFreeGeomColors".}
 proc XkbFreeGeomDoodads*(doodads: PXkbDoodadPtr, nDoodads: int16, freeAll: bool){.
     libx11c, importc: "XkbFreeGeomDoodads".}
-proc XkbFreeGeomProperties*(geom: PXkbGeometryPtr, first: int16, count: int16, 
-                            freeAll: bool){.libx11c, 
+proc XkbFreeGeomProperties*(geom: PXkbGeometryPtr, first: int16, count: int16,
+                            freeAll: bool){.libx11c,
     importc: "XkbFreeGeomProperties".}
-proc XkbFreeGeomOverlayKeys*(row: PXkbOverlayRowPtr, first: int16, count: int16, 
-                             freeAll: bool){.libx11c, 
+proc XkbFreeGeomOverlayKeys*(row: PXkbOverlayRowPtr, first: int16, count: int16,
+                             freeAll: bool){.libx11c,
     importc: "XkbFreeGeomOverlayKeys".}
-proc XkbFreeGeomOverlayRows*(overlay: PXkbOverlayPtr, first: int16, 
+proc XkbFreeGeomOverlayRows*(overlay: PXkbOverlayPtr, first: int16,
                              count: int16, freeAll: bool){.libx11c, importc: "XkbFreeGeomOverlayRows".}
-proc XkbFreeGeomOverlays*(section: PXkbSectionPtr, first: int16, count: int16, 
-                          freeAll: bool){.libx11c, 
+proc XkbFreeGeomOverlays*(section: PXkbSectionPtr, first: int16, count: int16,
+                          freeAll: bool){.libx11c,
     importc: "XkbFreeGeomOverlays".}
 proc XkbFreeGeomKeys*(row: PXkbRowPtr, first: int16, count: int16, freeAll: bool){.
     libx11c, importc: "XkbFreeGeomKeys".}
-proc XkbFreeGeomRows*(section: PXkbSectionPtr, first: int16, count: int16, 
-                      freeAll: bool){.libx11c, 
+proc XkbFreeGeomRows*(section: PXkbSectionPtr, first: int16, count: int16,
+                      freeAll: bool){.libx11c,
                                       importc: "XkbFreeGeomRows".}
-proc XkbFreeGeomSections*(geom: PXkbGeometryPtr, first: int16, count: int16, 
-                          freeAll: bool){.libx11c, 
+proc XkbFreeGeomSections*(geom: PXkbGeometryPtr, first: int16, count: int16,
+                          freeAll: bool){.libx11c,
     importc: "XkbFreeGeomSections".}
-proc XkbFreeGeomPoints*(outline: PXkbOutlinePtr, first: int16, count: int16, 
-                        freeAll: bool){.libx11c, 
+proc XkbFreeGeomPoints*(outline: PXkbOutlinePtr, first: int16, count: int16,
+                        freeAll: bool){.libx11c,
                                         importc: "XkbFreeGeomPoints".}
-proc XkbFreeGeomOutlines*(shape: PXkbShapePtr, first: int16, count: int16, 
-                          freeAll: bool){.libx11c, 
+proc XkbFreeGeomOutlines*(shape: PXkbShapePtr, first: int16, count: int16,
+                          freeAll: bool){.libx11c,
     importc: "XkbFreeGeomOutlines".}
-proc XkbFreeGeomShapes*(geom: PXkbGeometryPtr, first: int16, count: int16, 
-                        freeAll: bool){.libx11c, 
+proc XkbFreeGeomShapes*(geom: PXkbGeometryPtr, first: int16, count: int16,
+                        freeAll: bool){.libx11c,
                                         importc: "XkbFreeGeomShapes".}
 proc XkbFreeGeometry*(geom: PXkbGeometryPtr, which: int16, freeMap: bool){.
     libx11c, importc: "XkbFreeGeometry".}
@@ -1792,47 +1792,47 @@ proc XkbSetGeometryProc*(dpy: PDisplay, deviceSpec: int16, geom: PXkbGeometryPtr
     libx11c, importc: "XkbSetGeometry".}
 proc XkbComputeShapeTop*(shape: PXkbShapePtr, bounds: PXkbBoundsPtr): bool{.
     libx11c, importc: "XkbComputeShapeTop".}
-proc XkbComputeShapeBounds*(shape: PXkbShapePtr): bool{.libx11c, 
+proc XkbComputeShapeBounds*(shape: PXkbShapePtr): bool{.libx11c,
     importc: "XkbComputeShapeBounds".}
-proc XkbComputeRowBounds*(geom: PXkbGeometryPtr, section: PXkbSectionPtr, 
-                          row: PXkbRowPtr): bool{.libx11c, 
+proc XkbComputeRowBounds*(geom: PXkbGeometryPtr, section: PXkbSectionPtr,
+                          row: PXkbRowPtr): bool{.libx11c,
     importc: "XkbComputeRowBounds".}
 proc XkbComputeSectionBounds*(geom: PXkbGeometryPtr, section: PXkbSectionPtr): bool{.
     libx11c, importc: "XkbComputeSectionBounds".}
-proc XkbFindOverlayForKey*(geom: PXkbGeometryPtr, wanted: PXkbSectionPtr, 
-                           under: cstring): cstring{.libx11c, 
+proc XkbFindOverlayForKey*(geom: PXkbGeometryPtr, wanted: PXkbSectionPtr,
+                           under: cstring): cstring{.libx11c,
     importc: "XkbFindOverlayForKey".}
 proc XkbGetGeometryProc*(dpy: PDisplay, xkb: PXkbDescPtr): TStatus{.libx11c, importc: "XkbGetGeometry".}
 proc XkbGetNamedGeometry*(dpy: PDisplay, xkb: PXkbDescPtr, name: TAtom): TStatus{.
     libx11c, importc: "XkbGetNamedGeometry".}
-when defined(XKB_IN_SERVER): 
-  proc SrvXkbAddGeomKeyAlias*(geom: PXkbGeometryPtr, alias: cstring, 
+when defined(XKB_IN_SERVER):
+  proc SrvXkbAddGeomKeyAlias*(geom: PXkbGeometryPtr, alias: cstring,
                               float: cstring): PXkbKeyAliasPtr{.libx11c, importc: "XkbAddGeomKeyAlias".}
   proc SrvXkbAddGeomColor*(geom: PXkbGeometryPtr, spec: cstring, pixel: int16): PXkbColorPtr{.
       libx11c, importc: "XkbAddGeomColor".}
-  proc SrvXkbAddGeomDoodad*(geom: PXkbGeometryPtr, section: PXkbSectionPtr, 
-                            name: TAtom): PXkbDoodadPtr{.libx11c, 
+  proc SrvXkbAddGeomDoodad*(geom: PXkbGeometryPtr, section: PXkbSectionPtr,
+                            name: TAtom): PXkbDoodadPtr{.libx11c,
       importc: "XkbAddGeomDoodad".}
   proc SrvXkbAddGeomKey*(geom: PXkbGeometryPtr, alias: cstring, float: cstring): PXkbKeyAliasPtr{.
       libx11c, importc: "XkbAddGeomKeyAlias".}
   proc SrvXkbAddGeomOutline*(shape: PXkbShapePtr, sz_points: int16): PXkbOutlinePtr{.
       libx11c, importc: "XkbAddGeomOutline".}
-  proc SrvXkbAddGeomOverlay*(overlay: PXkbOverlayPtr, row: PXkbOverlayRowPtr, 
+  proc SrvXkbAddGeomOverlay*(overlay: PXkbOverlayPtr, row: PXkbOverlayRowPtr,
                              over: cstring, under: cstring): PXkbOverlayKeyPtr{.
       libx11c, importc: "XkbAddGeomOverlayKey".}
-  proc SrvXkbAddGeomOverlayRow*(overlay: PXkbOverlayPtr, row_under: int16, 
+  proc SrvXkbAddGeomOverlayRow*(overlay: PXkbOverlayPtr, row_under: int16,
                                 sz_keys: int16): PXkbOverlayRowPtr{.libx11c, importc: "XkbAddGeomOverlayRow".}
-  proc SrvXkbAddGeomOverlayKey*(overlay: PXkbOverlayPtr, row: PXkbOverlayRowPtr, 
+  proc SrvXkbAddGeomOverlayKey*(overlay: PXkbOverlayPtr, row: PXkbOverlayRowPtr,
                                 over: cstring, under: cstring): PXkbOverlayKeyPtr{.
       libx11c, importc: "XkbAddGeomOverlayKey".}
-  proc SrvXkbAddGeomProperty*(geom: PXkbGeometryPtr, name: cstring, 
+  proc SrvXkbAddGeomProperty*(geom: PXkbGeometryPtr, name: cstring,
                               value: cstring): PXkbPropertyPtr{.libx11c, importc: "XkbAddGeomProperty".}
   proc SrvXkbAddGeomRow*(section: PXkbSectionPtr, sz_keys: int16): PXkbRowPtr{.
       libx11c, importc: "XkbAddGeomRow".}
-  proc SrvXkbAddGeomSection*(geom: PXkbGeometryPtr, name: TAtom, sz_rows: int16, 
+  proc SrvXkbAddGeomSection*(geom: PXkbGeometryPtr, name: TAtom, sz_rows: int16,
                              sz_doodads: int16, sz_overlays: int16): PXkbSectionPtr{.
       libx11c, importc: "XkbAddGeomSection".}
-  proc SrvXkbAddGeomShape*(geom: PXkbGeometryPtr, name: TAtom, 
+  proc SrvXkbAddGeomShape*(geom: PXkbGeometryPtr, name: TAtom,
                            sz_outlines: int16): PXkbShapePtr{.libx11c, importc: "XkbAddGeomShape".}
   proc SrvXkbAllocGeomKeyAliases*(geom: PXkbGeometryPtr, nAliases: int16): TStatus{.
       libx11c, importc: "XkbAllocGeomKeyAliases".}
@@ -1862,37 +1862,37 @@ when defined(XKB_IN_SERVER):
       libx11c, importc: "XkbAllocGeomShapes".}
   proc SrvXkbAllocGeometry*(xkb: PXkbDescPtr, sizes: PXkbGeometrySizesPtr): TStatus{.
       libx11c, importc: "XkbAllocGeometry".}
-  proc SrvXkbFreeGeomKeyAliases*(geom: PXkbGeometryPtr, first: int16, 
+  proc SrvXkbFreeGeomKeyAliases*(geom: PXkbGeometryPtr, first: int16,
                                  count: int16, freeAll: bool){.libx11c, importc: "XkbFreeGeomKeyAliases".}
-  proc SrvXkbFreeGeomColors*(geom: PXkbGeometryPtr, first: int16, count: int16, 
-                             freeAll: bool){.libx11c, 
+  proc SrvXkbFreeGeomColors*(geom: PXkbGeometryPtr, first: int16, count: int16,
+                             freeAll: bool){.libx11c,
       importc: "XkbFreeGeomColors".}
-  proc SrvXkbFreeGeomDoodads*(doodads: PXkbDoodadPtr, nDoodads: int16, 
-                              freeAll: bool){.libx11c, 
+  proc SrvXkbFreeGeomDoodads*(doodads: PXkbDoodadPtr, nDoodads: int16,
+                              freeAll: bool){.libx11c,
       importc: "XkbFreeGeomDoodads".}
-  proc SrvXkbFreeGeomProperties*(geom: PXkbGeometryPtr, first: int16, 
+  proc SrvXkbFreeGeomProperties*(geom: PXkbGeometryPtr, first: int16,
                                  count: int16, freeAll: bool){.libx11c, importc: "XkbFreeGeomProperties".}
-  proc SrvXkbFreeGeomOverlayKeys*(row: PXkbOverlayRowPtr, first: int16, 
+  proc SrvXkbFreeGeomOverlayKeys*(row: PXkbOverlayRowPtr, first: int16,
                                   count: int16, freeAll: bool){.libx11c, importc: "XkbFreeGeomOverlayKeys".}
-  proc SrvXkbFreeGeomOverlayRows*(overlay: PXkbOverlayPtr, first: int16, 
+  proc SrvXkbFreeGeomOverlayRows*(overlay: PXkbOverlayPtr, first: int16,
                                   count: int16, freeAll: bool){.libx11c, importc: "XkbFreeGeomOverlayRows".}
-  proc SrvXkbFreeGeomOverlays*(section: PXkbSectionPtr, first: int16, 
+  proc SrvXkbFreeGeomOverlays*(section: PXkbSectionPtr, first: int16,
                                count: int16, freeAll: bool){.libx11c, importc: "XkbFreeGeomOverlays".}
-  proc SrvXkbFreeGeomKeys*(row: PXkbRowPtr, first: int16, count: int16, 
-                           freeAll: bool){.libx11c, 
+  proc SrvXkbFreeGeomKeys*(row: PXkbRowPtr, first: int16, count: int16,
+                           freeAll: bool){.libx11c,
       importc: "XkbFreeGeomKeys".}
-  proc SrvXkbFreeGeomRows*(section: PXkbSectionPtr, first: int16, count: int16, 
-                           freeAll: bool){.libx11c, 
+  proc SrvXkbFreeGeomRows*(section: PXkbSectionPtr, first: int16, count: int16,
+                           freeAll: bool){.libx11c,
       importc: "XkbFreeGeomRows".}
-  proc SrvXkbFreeGeomSections*(geom: PXkbGeometryPtr, first: int16, 
+  proc SrvXkbFreeGeomSections*(geom: PXkbGeometryPtr, first: int16,
                                count: int16, freeAll: bool){.libx11c, importc: "XkbFreeGeomSections".}
-  proc SrvXkbFreeGeomPoints*(outline: PXkbOutlinePtr, first: int16, 
+  proc SrvXkbFreeGeomPoints*(outline: PXkbOutlinePtr, first: int16,
                              count: int16, freeAll: bool){.libx11c, importc: "XkbFreeGeomPoints".}
-  proc SrvXkbFreeGeomOutlines*(shape: PXkbShapePtr, first: int16, count: int16, 
-                               freeAll: bool){.libx11c, 
+  proc SrvXkbFreeGeomOutlines*(shape: PXkbShapePtr, first: int16, count: int16,
+                               freeAll: bool){.libx11c,
       importc: "XkbFreeGeomOutlines".}
-  proc SrvXkbFreeGeomShapes*(geom: PXkbGeometryPtr, first: int16, count: int16, 
-                             freeAll: bool){.libx11c, 
+  proc SrvXkbFreeGeomShapes*(geom: PXkbGeometryPtr, first: int16, count: int16,
+                             freeAll: bool){.libx11c,
       importc: "XkbFreeGeomShapes".}
   proc SrvXkbFreeGeometry*(geom: PXkbGeometryPtr, which: int16, freeMap: bool){.
       libx11c, importc: "XkbFreeGeometry".}
@@ -1901,487 +1901,487 @@ when defined(XKB_IN_SERVER):
 import                        #************************************ xkb ************************************
   xi
 
-proc XkbLegalXILedClass(c: int): bool = 
+proc XkbLegalXILedClass(c: int): bool =
   ##define XkbLegalXILedClass(c) (((c)==KbdFeedbackClass)||((c)==LedFeedbackClass)||
   #                                ((c)==XkbDfltXIClass)||((c)==XkbAllXIClasses))
-  Result = (c == KbdFeedbackClass) or (c == LedFeedbackClass) or
+  result = (c == KbdFeedbackClass) or (c == LedFeedbackClass) or
       (c == XkbDfltXIClass) or (c == XkbAllXIClasses)
 
-proc XkbLegalXIBellClass(c: int): bool = 
+proc XkbLegalXIBellClass(c: int): bool =
   ##define XkbLegalXIBellClass(c) (((c)==KbdFeedbackClass)||((c)==BellFeedbackClass)||
   #                                 ((c)==XkbDfltXIClass)||((c)==XkbAllXIClasses))
-  Result = (c == KbdFeedbackClass) or (c == BellFeedbackClass) or
+  result = (c == KbdFeedbackClass) or (c == BellFeedbackClass) or
       (c == XkbDfltXIClass) or (c == XkbAllXIClasses)
 
-proc XkbExplicitXIDevice(c: int): bool = 
+proc XkbExplicitXIDevice(c: int): bool =
   ##define XkbExplicitXIDevice(c) (((c)&(~0xff))==0)
-  Result = (c and (not 0x000000FF)) == 0
+  result = (c and (not 0x000000FF)) == 0
 
-proc XkbExplicitXIClass(c: int): bool = 
+proc XkbExplicitXIClass(c: int): bool =
   ##define XkbExplicitXIClass(c) (((c)&(~0xff))==0)
-  Result = (c and (not 0x000000FF)) == 0
+  result = (c and (not 0x000000FF)) == 0
 
-proc XkbExplicitXIId(c: int): bool = 
+proc XkbExplicitXIId(c: int): bool =
   ##define XkbExplicitXIId(c) (((c)&(~0xff))==0)
-  Result = (c and (not 0x000000FF)) == 0
+  result = (c and (not 0x000000FF)) == 0
 
-proc XkbSingleXIClass(c: int): bool = 
+proc XkbSingleXIClass(c: int): bool =
   ##define XkbSingleXIClass(c) ((((c)&(~0xff))==0)||((c)==XkbDfltXIClass))
-  Result = ((c and (not 0x000000FF)) == 0) or (c == XkbDfltXIClass)
+  result = ((c and (not 0x000000FF)) == 0) or (c == XkbDfltXIClass)
 
-proc XkbSingleXIId(c: int): bool = 
+proc XkbSingleXIId(c: int): bool =
   ##define XkbSingleXIId(c) ((((c)&(~0xff))==0)||((c)==XkbDfltXIId))
-  Result = ((c and (not 0x000000FF)) == 0) or (c == XkbDfltXIId)
+  result = ((c and (not 0x000000FF)) == 0) or (c == XkbDfltXIId)
 
-proc XkbBuildCoreState(m, g: int): int = 
+proc XkbBuildCoreState(m, g: int): int =
   ##define XkbBuildCoreState(m,g) ((((g)&0x3)<<13)|((m)&0xff))
-  Result = ((g and 0x00000003) shl 13) or (m and 0x000000FF)
+  result = ((g and 0x00000003) shl 13) or (m and 0x000000FF)
 
-proc XkbGroupForCoreState(s: int): int = 
+proc XkbGroupForCoreState(s: int): int =
   ##define XkbGroupForCoreState(s) (((s)>>13)&0x3)
-  Result = (s shr 13) and 0x00000003
+  result = (s shr 13) and 0x00000003
 
-proc XkbIsLegalGroup(g: int): bool = 
+proc XkbIsLegalGroup(g: int): bool =
   ##define XkbIsLegalGroup(g) (((g)>=0)&&((g)<XkbNumKbdGroups))
-  Result = (g >= 0) and (g < XkbNumKbdGroups)
+  result = (g >= 0) and (g < XkbNumKbdGroups)
 
-proc XkbSA_ValOp(a: int): int = 
+proc XkbSA_ValOp(a: int): int =
   ##define XkbSA_ValOp(a) ((a)&XkbSA_ValOpMask)
-  Result = a and XkbSA_ValOpMask
+  result = a and XkbSA_ValOpMask
 
-proc XkbSA_ValScale(a: int): int = 
+proc XkbSA_ValScale(a: int): int =
   ##define XkbSA_ValScale(a) ((a)&XkbSA_ValScaleMask)
-  Result = a and XkbSA_ValScaleMask
+  result = a and XkbSA_ValScaleMask
 
-proc XkbIsModAction(a: PXkbAnyAction): bool = 
+proc XkbIsModAction(a: PXkbAnyAction): bool =
   ##define XkbIsModAction(a) (((a)->type>=Xkb_SASetMods)&&((a)->type<=XkbSA_LockMods))
-  Result = (ze(a.theType) >= XkbSA_SetMods) and (ze(a.theType) <= XkbSA_LockMods)
+  result = (ze(a.theType) >= XkbSA_SetMods) and (ze(a.theType) <= XkbSA_LockMods)
 
-proc XkbIsGroupAction(a: PXkbAnyAction): bool = 
+proc XkbIsGroupAction(a: PXkbAnyAction): bool =
   ##define XkbIsGroupAction(a) (((a)->type>=XkbSA_SetGroup)&&((a)->type<=XkbSA_LockGroup))
-  Result = (ze(a.theType) >= XkbSA_SetGroup) or (ze(a.theType) <= XkbSA_LockGroup)
+  result = (ze(a.theType) >= XkbSA_SetGroup) or (ze(a.theType) <= XkbSA_LockGroup)
 
-proc XkbIsPtrAction(a: PXkbAnyAction): bool = 
+proc XkbIsPtrAction(a: PXkbAnyAction): bool =
   ##define XkbIsPtrAction(a) (((a)->type>=XkbSA_MovePtr)&&((a)->type<=XkbSA_SetPtrDflt))
-  Result = (ze(a.theType) >= XkbSA_MovePtr) and
+  result = (ze(a.theType) >= XkbSA_MovePtr) and
       (ze(a.theType) <= XkbSA_SetPtrDflt)
 
-proc XkbIsLegalKeycode(k: int): bool = 
+proc XkbIsLegalKeycode(k: int): bool =
   ##define        XkbIsLegalKeycode(k)    (((k)>=XkbMinLegalKeyCode)&&((k)<=XkbMaxLegalKeyCode))
-  Result = (k >= XkbMinLegalKeyCode) and (k <= XkbMaxLegalKeyCode)
+  result = (k >= XkbMinLegalKeyCode) and (k <= XkbMaxLegalKeyCode)
 
-proc XkbShiftLevel(n: int8): int8 = 
+proc XkbShiftLevel(n: int8): int8 =
   ##define XkbShiftLevel(n) ((n)-1)
-  Result = n - 1'i8
+  result = n - 1'i8
 
-proc XkbShiftLevelMask(n: int8): int8 = 
+proc XkbShiftLevelMask(n: int8): int8 =
   ##define XkbShiftLevelMask(n) (1<<((n)-1))
-  Result = 1'i8 shl (n - 1'i8)
+  result = 1'i8 shl (n - 1'i8)
 
-proc XkbCharToInt(v: int8): int16 = 
-  ##define XkbCharToInt(v) ((v)&0x80?(int)((v)|(~0xff)):(int)((v)&0x7f))
-  if ((v and 0x80'i8) != 0'i8): Result = v or (not 0xFF'i16)
-  else: Result = int16(v and 0x7F'i8)
-  
-proc XkbIntTo2Chars(i: int16, h, L: var int8) = 
-  ##define XkbIntTo2Chars(i,h,l) (((h)=((i>>8)&0xff)),((l)=((i)&0xff)))
+proc XkbcharToInt(v: int8): int16 =
+  ##define XkbcharToInt(v) ((v)&0x80?(int)((v)|(~0xff)):(int)((v)&0x7f))
+  if ((v and 0x80'i8) != 0'i8): result = v or (not 0xFF'i16)
+  else: result = int16(v and 0x7F'i8)
+
+proc XkbIntTo2chars(i: int16, h, L: var int8) =
+  ##define XkbIntTo2chars(i,h,l) (((h)=((i>>8)&0xff)),((l)=((i)&0xff)))
   h = toU8((i shr 8'i16) and 0x00FF'i16)
   L = toU8(i and 0xFF'i16)
 
-proc Xkb2CharsToInt(h, L: int8): int16 = 
-  when defined(cpu64): 
-    ##define Xkb2CharsToInt(h,l) ((h)&0x80?(int)(((h)<<8)|(l)|(~0xffff)): (int)(((h)<<8)|(l)&0x7fff))
-    if (h and 0x80'i8) != 0'i8: 
-      Result = toU16((ze(h) shl 8) or ze(L) or not 0x0000FFFF)
-    else: 
-      Result = toU16((ze(h) shl 8) or ze(L) and 0x00007FFF)
-  else: 
-    ##define Xkb2CharsToInt(h,l) ((short)(((h)<<8)|(l)))
-    Result = toU16(ze(h) shl 8 or ze(L))
+proc Xkb2charsToInt(h, L: int8): int16 =
+  when defined(cpu64):
+    ##define Xkb2charsToInt(h,l) ((h)&0x80?(int)(((h)<<8)|(l)|(~0xffff)): (int)(((h)<<8)|(l)&0x7fff))
+    if (h and 0x80'i8) != 0'i8:
+      result = toU16((ze(h) shl 8) or ze(L) or not 0x0000FFFF)
+    else:
+      result = toU16((ze(h) shl 8) or ze(L) and 0x00007FFF)
+  else:
+    ##define Xkb2charsToInt(h,l) ((short)(((h)<<8)|(l)))
+    result = toU16(ze(h) shl 8 or ze(L))
 
-proc XkbModLocks(s: PXkbStatePtr): int8 = 
+proc XkbModLocks(s: PXkbStatePtr): int8 =
   ##define XkbModLocks(s) ((s)->locked_mods)
-  Result = s.locked_mods
+  result = s.locked_mods
 
-proc XkbStateMods(s: PXkbStatePtr): int16 = 
+proc XkbStateMods(s: PXkbStatePtr): int16 =
   ##define XkbStateMods(s) ((s)->base_mods|(s)->latched_mods|XkbModLocks(s))
-  Result = s.base_mods or s.latched_mods or XkbModLocks(s)
+  result = s.base_mods or s.latched_mods or XkbModLocks(s)
 
-proc XkbGroupLock(s: PXkbStatePtr): int8 = 
+proc XkbGroupLock(s: PXkbStatePtr): int8 =
   ##define XkbGroupLock(s) ((s)->locked_group)
-  Result = s.locked_group
+  result = s.locked_group
 
-proc XkbStateGroup(s: PXkbStatePtr): int16 = 
+proc XkbStateGroup(s: PXkbStatePtr): int16 =
   ##define XkbStateGroup(s) ((s)->base_group+(s)->latched_group+XkbGroupLock(s))
-  Result = S.base_group + (s.latched_group) + XkbGroupLock(s)
+  result = s.base_group + (s.latched_group) + XkbGroupLock(s)
 
-proc XkbStateFieldFromRec(s: PXkbStatePtr): int = 
+proc XkbStateFieldFromRec(s: PXkbStatePtr): int =
   ##define XkbStateFieldFromRec(s) XkbBuildCoreState((s)->lookup_mods,(s)->group)
-  Result = XkbBuildCoreState(s.lookup_mods, s.group)
+  result = XkbBuildCoreState(s.lookup_mods, s.group)
 
-proc XkbGrabStateFromRec(s: PXkbStatePtr): int = 
+proc XkbGrabStateFromRec(s: PXkbStatePtr): int =
   ##define XkbGrabStateFromRec(s) XkbBuildCoreState((s)->grab_mods,(s)->group)
-  Result = XkbBuildCoreState(s.grab_mods, s.group)
+  result = XkbBuildCoreState(s.grab_mods, s.group)
 
-proc XkbNumGroups(g: int16): int16 = 
+proc XkbNumGroups(g: int16): int16 =
   ##define XkbNumGroups(g) ((g)&0x0f)
-  Result = g and 0x0000000F'i16
+  result = g and 0x0000000F'i16
 
-proc XkbOutOfRangeGroupInfo(g: int16): int16 = 
+proc XkbOutOfRangeGroupInfo(g: int16): int16 =
   ##define XkbOutOfRangeGroupInfo(g) ((g)&0xf0)
-  Result = g and 0x000000F0'i16
+  result = g and 0x000000F0'i16
 
-proc XkbOutOfRangeGroupAction(g: int16): int16 = 
+proc XkbOutOfRangeGroupAction(g: int16): int16 =
   ##define XkbOutOfRangeGroupAction(g) ((g)&0xc0)
-  Result = g and 0x000000C0'i16
+  result = g and 0x000000C0'i16
 
-proc XkbOutOfRangeGroupNumber(g: int16): int16 = 
+proc XkbOutOfRangeGroupNumber(g: int16): int16 =
   ##define XkbOutOfRangeGroupNumber(g) (((g)&0x30)>>4)
-  Result = (g and 0x00000030'i16) shr 4'i16
+  result = (g and 0x00000030'i16) shr 4'i16
 
-proc XkbSetGroupInfo(g, w, n: int16): int16 = 
+proc XkbSetGroupInfo(g, w, n: int16): int16 =
   ##define XkbSetGroupInfo(g,w,n) (((w)&0xc0)|(((n)&3)<<4)|((g)&0x0f))
-  Result = (w and 0x000000C0'i16) or 
+  result = (w and 0x000000C0'i16) or
     ((n and 3'i16) shl 4'i16) or (g and 0x0000000F'i16)
 
-proc XkbSetNumGroups(g, n: int16): int16 = 
+proc XkbSetNumGroups(g, n: int16): int16 =
   ##define XkbSetNumGroups(g,n) (((g)&0xf0)|((n)&0x0f))
-  Result = (g and 0x000000F0'i16) or (n and 0x0000000F'i16)
+  result = (g and 0x000000F0'i16) or (n and 0x0000000F'i16)
 
-proc XkbModActionVMods(a: PXkbModAction): int16 = 
+proc XkbModActionVMods(a: PXkbModAction): int16 =
   ##define XkbModActionVMods(a) ((short)(((a)->vmods1<<8)|((a)->vmods2)))
-  Result = toU16((ze(a.vmods1) shl 8) or ze(a.vmods2))
+  result = toU16((ze(a.vmods1) shl 8) or ze(a.vmods2))
 
-proc XkbSetModActionVMods(a: PXkbModAction, v: int8) = 
+proc XkbSetModActionVMods(a: PXkbModAction, v: int8) =
   ##define XkbSetModActionVMods(a,v) (((a)->vmods1=(((v)>>8)&0xff)),(a)->vmods2=((v)&0xff))
   a.vmods1 = toU8((ze(v) shr 8) and 0x000000FF)
   a.vmods2 = toU8(ze(v) and 0x000000FF)
 
-proc XkbSAGroup(a: PXkbGroupAction): int8 = 
-  ##define XkbSAGroup(a) (XkbCharToInt((a)->group_XXX))
-  Result = int8(XkbCharToInt(a.group_XXX))
+proc XkbSAGroup(a: PXkbGroupAction): int8 =
+  ##define XkbSAGroup(a) (XkbcharToInt((a)->group_XXX))
+  result = int8(XkbcharToInt(a.group_XXX))
 
-proc XkbSASetGroupProc(a: PXkbGroupAction, g: int8) = 
+proc XkbSASetGroupProc(a: PXkbGroupAction, g: int8) =
   ##define XkbSASetGroup(a,g) ((a)->group_XXX=(g))
   a.group_XXX = g
 
-proc XkbPtrActionX(a: PXkbPtrAction): int16 = 
-  ##define XkbPtrActionX(a) (Xkb2CharsToInt((a)->high_XXX,(a)->low_XXX))
-  Result = int16(Xkb2CharsToInt(a.high_XXX, a.low_XXX))
+proc XkbPtrActionX(a: PXkbPtrAction): int16 =
+  ##define XkbPtrActionX(a) (Xkb2charsToInt((a)->high_XXX,(a)->low_XXX))
+  result = int16(Xkb2charsToInt(a.high_XXX, a.low_XXX))
 
-proc XkbPtrActionY(a: PXkbPtrAction): int16 = 
-  ##define XkbPtrActionY(a) (Xkb2CharsToInt((a)->high_YYY,(a)->low_YYY))
-  Result = int16(Xkb2CharsToInt(a.high_YYY, a.low_YYY))
+proc XkbPtrActionY(a: PXkbPtrAction): int16 =
+  ##define XkbPtrActionY(a) (Xkb2charsToInt((a)->high_YYY,(a)->low_YYY))
+  result = int16(Xkb2charsToInt(a.high_YYY, a.low_YYY))
 
-proc XkbSetPtrActionX(a: PXkbPtrAction, x: int8) = 
-  ##define XkbSetPtrActionX(a,x) (XkbIntTo2Chars(x,(a)->high_XXX,(a)->low_XXX))
-  XkbIntTo2Chars(x, a.high_XXX, a.low_XXX)
+proc XkbSetPtrActionX(a: PXkbPtrAction, x: int8) =
+  ##define XkbSetPtrActionX(a,x) (XkbIntTo2chars(x,(a)->high_XXX,(a)->low_XXX))
+  XkbIntTo2chars(x, a.high_XXX, a.low_XXX)
 
-proc XkbSetPtrActionY(a: PXkbPtrAction, y: int8) = 
-  ##define XkbSetPtrActionY(a,y) (XkbIntTo2Chars(y,(a)->high_YYY,(a)->low_YYY))
-  XkbIntTo2Chars(y, a.high_YYY, a.low_YYY)
+proc XkbSetPtrActionY(a: PXkbPtrAction, y: int8) =
+  ##define XkbSetPtrActionY(a,y) (XkbIntTo2chars(y,(a)->high_YYY,(a)->low_YYY))
+  XkbIntTo2chars(y, a.high_YYY, a.low_YYY)
 
-proc XkbSAPtrDfltValue(a: PXkbPtrDfltAction): int8 = 
-  ##define XkbSAPtrDfltValue(a) (XkbCharToInt((a)->valueXXX))
-  Result = int8(XkbCharToInt(a.valueXXX))
+proc XkbSAPtrDfltValue(a: PXkbPtrDfltAction): int8 =
+  ##define XkbSAPtrDfltValue(a) (XkbcharToInt((a)->valueXXX))
+  result = int8(XkbcharToInt(a.valueXXX))
 
-proc XkbSASetPtrDfltValue(a: PXkbPtrDfltAction, c: pointer) = 
+proc XkbSASetPtrDfltValue(a: PXkbPtrDfltAction, c: pointer) =
   ##define XkbSASetPtrDfltValue(a,c) ((a)->valueXXX= ((c)&0xff))
   a.valueXXX = toU8(cast[int](c))
 
-proc XkbSAScreen(a: PXkbSwitchScreenAction): int8 = 
-  ##define XkbSAScreen(a) (XkbCharToInt((a)->screenXXX))
-  Result = toU8(XkbCharToInt(a.screenXXX))
+proc XkbSAScreen(a: PXkbSwitchScreenAction): int8 =
+  ##define XkbSAScreen(a) (XkbcharToInt((a)->screenXXX))
+  result = toU8(XkbcharToInt(a.screenXXX))
 
-proc XkbSASetScreen(a: PXkbSwitchScreenAction, s: pointer) = 
+proc XkbSASetScreen(a: PXkbSwitchScreenAction, s: pointer) =
   ##define XkbSASetScreen(a,s) ((a)->screenXXX= ((s)&0xff))
   a.screenXXX = toU8(cast[int](s))
 
-proc XkbActionSetCtrls(a: PXkbCtrlsAction, c: int8) = 
+proc XkbActionSetCtrls(a: PXkbCtrlsAction, c: int8) =
   ##define XkbActionSetCtrls(a,c) (((a)->ctrls3=(((c)>>24)&0xff)),((a)->ctrls2=(((c)>>16)&0xff)),
-  #                                 ((a)->ctrls1=(((c)>>8)&0xff)),((a)->ctrls0=((c)&0xff)))        
+  #                                 ((a)->ctrls1=(((c)>>8)&0xff)),((a)->ctrls0=((c)&0xff)))
   a.ctrls3 = toU8((ze(c) shr 24) and 0x000000FF)
   a.ctrls2 = toU8((ze(c) shr 16) and 0x000000FF)
   a.ctrls1 = toU8((ze(c) shr 8) and 0x000000FF)
   a.ctrls0 = toU8(ze(c) and 0x000000FF)
 
-proc XkbActionCtrls(a: PXkbCtrlsAction): int16 = 
+proc XkbActionCtrls(a: PXkbCtrlsAction): int16 =
   ##define XkbActionCtrls(a) ((((unsigned int)(a)->ctrls3)<<24)|(((unsigned int)(a)->ctrls2)<<16)|
-  #                            (((unsigned int)(a)->ctrls1)<<8)|((unsigned int)((a)->ctrls0)))      
-  Result = toU16((ze(a.ctrls3) shl 24) or (ze(a.ctrls2) shl 16) or 
+  #                            (((unsigned int)(a)->ctrls1)<<8)|((unsigned int)((a)->ctrls0)))
+  result = toU16((ze(a.ctrls3) shl 24) or (ze(a.ctrls2) shl 16) or
      (ze(a.ctrls1) shl 8) or ze(a.ctrls0))
 
-proc XkbSARedirectVMods(a: PXkbRedirectKeyAction): int16 = 
+proc XkbSARedirectVMods(a: PXkbRedirectKeyAction): int16 =
   ##define XkbSARedirectVMods(a) ((((unsigned int)(a)->vmods1)<<8)|((unsigned int)(a)->vmods0))
-  Result = toU16((ze(a.vmods1) shl 8) or ze(a.vmods0))
+  result = toU16((ze(a.vmods1) shl 8) or ze(a.vmods0))
 
-proc XkbSARedirectSetVMods(a: PXkbRedirectKeyAction, m: int8) = 
+proc XkbSARedirectSetVMods(a: PXkbRedirectKeyAction, m: int8) =
   ##define XkbSARedirectSetVMods(a,m) (((a)->vmods_mask1=(((m)>>8)&0xff)),((a)->vmods_mask0=((m)&0xff)))
   a.vmods_mask1 = toU8((ze(m) shr 8) and 0x000000FF)
   a.vmods_mask0 = toU8(ze(m) or 0x000000FF)
 
-proc XkbSARedirectVModsMask(a: PXkbRedirectKeyAction): int16 = 
+proc XkbSARedirectVModsMask(a: PXkbRedirectKeyAction): int16 =
   ##define XkbSARedirectVModsMask(a) ((((unsigned int)(a)->vmods_mask1)<<8)|
   #                                     ((unsigned int)(a)->vmods_mask0))
-  Result = toU16((ze(a.vmods_mask1) shl 8) or ze(a.vmods_mask0))
+  result = toU16((ze(a.vmods_mask1) shl 8) or ze(a.vmods_mask0))
 
-proc XkbSARedirectSetVModsMask(a: PXkbRedirectKeyAction, m: int8) = 
+proc XkbSARedirectSetVModsMask(a: PXkbRedirectKeyAction, m: int8) =
   ##define XkbSARedirectSetVModsMask(a,m) (((a)->vmods_mask1=(((m)>>8)&0xff)),((a)->vmods_mask0=((m)&0xff)))
   a.vmods_mask1 = toU8(ze(m) shr 8 and 0x000000FF)
   a.vmods_mask0 = toU8(ze(m) and 0x000000FF)
 
-proc XkbAX_AnyFeedback(c: PXkbControlsPtr): int16 = 
+proc XkbAX_AnyFeedback(c: PXkbControlsPtr): int16 =
   ##define XkbAX_AnyFeedback(c) ((c)->enabled_ctrls&XkbAccessXFeedbackMask)
-  Result = toU16(ze(c.enabled_ctrls) and XkbAccessXFeedbackMask)
+  result = toU16(ze(c.enabled_ctrls) and XkbAccessXFeedbackMask)
 
-proc XkbAX_NeedOption(c: PXkbControlsPtr, w: int16): int16 = 
+proc XkbAX_NeedOption(c: PXkbControlsPtr, w: int16): int16 =
   ##define XkbAX_NeedOption(c,w) ((c)->ax_options&(w))
-  Result = toU16(ze(c.ax_options) and ze(w))
+  result = toU16(ze(c.ax_options) and ze(w))
 
-proc XkbAX_NeedFeedback(c: PXkbControlsPtr, w: int16): bool = 
+proc XkbAX_NeedFeedback(c: PXkbControlsPtr, w: int16): bool =
   ##define XkbAX_NeedFeedback(c,w) (XkbAX_AnyFeedback(c)&&XkbAX_NeedOption(c,w))
-  Result = (XkbAX_AnyFeedback(c) > 0'i16) and (XkbAX_NeedOption(c, w) > 0'i16)
+  result = (XkbAX_AnyFeedback(c) > 0'i16) and (XkbAX_NeedOption(c, w) > 0'i16)
 
-proc XkbSMKeyActionsPtr(m: PXkbServerMapPtr, k: int16): PXkbAction = 
+proc XkbSMKeyActionsPtr(m: PXkbServerMapPtr, k: int16): PXkbAction =
   ##define XkbSMKeyActionsPtr(m,k) (&(m)->acts[(m)->key_acts[k]])
-  Result = addr(m.acts[ze(m.key_acts[ze(k)])])
+  result = addr(m.acts[ze(m.key_acts[ze(k)])])
 
-proc XkbCMKeyGroupInfo(m: PXkbClientMapPtr, k: int16): int8 = 
+proc XkbCMKeyGroupInfo(m: PXkbClientMapPtr, k: int16): int8 =
   ##define XkbCMKeyGroupInfo(m,k) ((m)->key_sym_map[k].group_info)
-  Result = m.key_sym_map[ze(k)].group_info
+  result = m.key_sym_map[ze(k)].group_info
 
-proc XkbCMKeyNumGroups(m: PXkbClientMapPtr, k: int16): int8 = 
+proc XkbCMKeyNumGroups(m: PXkbClientMapPtr, k: int16): int8 =
   ##define XkbCMKeyNumGroups(m,k) (XkbNumGroups((m)->key_sym_map[k].group_info))
-  Result = toU8(XkbNumGroups(m.key_sym_map[ze(k)].group_info))
+  result = toU8(XkbNumGroups(m.key_sym_map[ze(k)].group_info))
 
-proc XkbCMKeyGroupWidth(m: PXkbClientMapPtr, k: int16, g: int8): int8 = 
+proc XkbCMKeyGroupWidth(m: PXkbClientMapPtr, k: int16, g: int8): int8 =
   ##define XkbCMKeyGroupWidth(m,k,g) (XkbCMKeyType(m,k,g)->num_levels)
-  Result = XkbCMKeyType(m, k, g).num_levels
+  result = XkbCMKeyType(m, k, g).num_levels
 
-proc XkbCMKeyGroupsWidth(m: PXkbClientMapPtr, K: int16): int8 = 
+proc XkbCMKeyGroupsWidth(m: PXkbClientMapPtr, k: int16): int8 =
   ##define XkbCMKeyGroupsWidth(m,k) ((m)->key_sym_map[k].width)
-  Result = m.key_sym_map[ze(k)].width
+  result = m.key_sym_map[ze(k)].width
 
-proc XkbCMKeyTypeIndex(m: PXkbClientMapPtr, k: int16, g: int8): int8 = 
+proc XkbCMKeyTypeIndex(m: PXkbClientMapPtr, k: int16, g: int8): int8 =
   ##define XkbCMKeyTypeIndex(m,k,g) ((m)->key_sym_map[k].kt_index[g&0x3])
-  Result = m.key_sym_map[ze(k)].kt_index[ze(g) and 0x00000003]
+  result = m.key_sym_map[ze(k)].kt_index[ze(g) and 0x00000003]
 
-proc XkbCMKeyType(m: PXkbClientMapPtr, k: int16, g: int8): PXkbKeyTypePtr = 
+proc XkbCMKeyType(m: PXkbClientMapPtr, k: int16, g: int8): PXkbKeyTypePtr =
   ##define XkbCMKeyType(m,k,g) (&(m)->types[XkbCMKeyTypeIndex(m,k,g)])
-  Result = addr(m.types[ze(XkbCMKeyTypeIndex(m, k, g))])
+  result = addr(m.types[ze(XkbCMKeyTypeIndex(m, k, g))])
 
-proc XkbCMKeyNumSyms(m: PXkbClientMapPtr, k: int16): int16 = 
+proc XkbCMKeyNumSyms(m: PXkbClientMapPtr, k: int16): int16 =
   ##define XkbCMKeyNumSyms(m,k) (XkbCMKeyGroupsWidth(m,k)*XkbCMKeyNumGroups(m,k))
-  Result = toU16(ze(XkbCMKeyGroupsWidth(m, k)) or ze(XkbCMKeyNumGroups(m, k)))
+  result = toU16(ze(XkbCMKeyGroupsWidth(m, k)) or ze(XkbCMKeyNumGroups(m, k)))
 
-proc XkbCMKeySymsOffset(m: PXkbClientMapPtr, k: int16): int8 = 
+proc XkbCMKeySymsOffset(m: PXkbClientMapPtr, k: int16): int8 =
   ##define XkbCMKeySymsOffset(m,k) ((m)->key_sym_map[k].offset)
-  Result = m.key_sym_map[ze(k)].offset
+  result = m.key_sym_map[ze(k)].offset
 
-proc XkbCMKeySymsPtr*(m: PXkbClientMapPtr, k: int16): PKeySym = 
+proc XkbCMKeySymsPtr*(m: PXkbClientMapPtr, k: int16): PKeySym =
   ##define XkbCMKeySymsPtr(m,k) (&(m)->syms[XkbCMKeySymsOffset(m,k)])
-  Result = addr(m.syms[ze(XkbCMKeySymsOffset(m, k))])
+  result = addr(m.syms[ze(XkbCMKeySymsOffset(m, k))])
 
-proc XkbIM_IsAuto(i: PXkbIndicatorMapPtr): bool = 
+proc XkbIM_IsAuto(i: PXkbIndicatorMapPtr): bool =
   ##define XkbIM_IsAuto(i) ((((i)->flags&XkbIM_NoAutomatic)==0)&&(((i)->which_groups&&(i)->groups)||
   #                           ((i)->which_mods&&(i)->mods.mask)||  ((i)->ctrls)))
-  Result = ((ze(i.flags) and XkbIM_NoAutomatic) == 0) and
+  result = ((ze(i.flags) and XkbIM_NoAutomatic) == 0) and
       (((i.which_groups > 0'i8) and (i.groups > 0'i8)) or
       ((i.which_mods > 0'i8) and (i.mods.mask > 0'i8)) or (i.ctrls > 0'i8))
 
-proc XkbIM_InUse(i: PXkbIndicatorMapPtr): bool = 
-  ##define XkbIM_InUse(i) (((i)->flags)||((i)->which_groups)||((i)->which_mods)||((i)->ctrls)) 
-  Result = (i.flags > 0'i8) or (i.which_groups > 0'i8) or (i.which_mods > 0'i8) or
+proc XkbIM_InUse(i: PXkbIndicatorMapPtr): bool =
+  ##define XkbIM_InUse(i) (((i)->flags)||((i)->which_groups)||((i)->which_mods)||((i)->ctrls))
+  result = (i.flags > 0'i8) or (i.which_groups > 0'i8) or (i.which_mods > 0'i8) or
       (i.ctrls > 0'i8)
 
-proc XkbKeyKeyTypeIndex(d: PXkbDescPtr, k: int16, g: int8): int8 = 
+proc XkbKeyKeyTypeIndex(d: PXkbDescPtr, k: int16, g: int8): int8 =
   ##define XkbKeyKeyTypeIndex(d,k,g)      (XkbCMKeyTypeIndex((d)->map,k,g))
-  Result = XkbCMKeyTypeIndex(d.map, k, g)
+  result = XkbCMKeyTypeIndex(d.map, k, g)
 
-proc XkbKeyKeyType(d: PXkbDescPtr, k: int16, g: int8): PXkbKeyTypePtr = 
+proc XkbKeyKeyType(d: PXkbDescPtr, k: int16, g: int8): PXkbKeyTypePtr =
   ##define XkbKeyKeyType(d,k,g) (XkbCMKeyType((d)->map,k,g))
-  Result = XkbCMKeyType(d.map, k, g)
+  result = XkbCMKeyType(d.map, k, g)
 
-proc XkbKeyGroupWidth(d: PXkbDescPtr, k: int16, g: int8): int8 = 
+proc XkbKeyGroupWidth(d: PXkbDescPtr, k: int16, g: int8): int8 =
   ##define XkbKeyGroupWidth(d,k,g) (XkbCMKeyGroupWidth((d)->map,k,g))
-  Result = XkbCMKeyGroupWidth(d.map, k, g)
+  result = XkbCMKeyGroupWidth(d.map, k, g)
 
-proc XkbKeyGroupsWidth(d: PXkbDescPtr, k: int16): int8 = 
+proc XkbKeyGroupsWidth(d: PXkbDescPtr, k: int16): int8 =
   ##define XkbKeyGroupsWidth(d,k) (XkbCMKeyGroupsWidth((d)->map,k))
-  Result = XkbCMKeyGroupsWidth(d.map, k)
+  result = XkbCMKeyGroupsWidth(d.map, k)
 
-proc XkbKeyGroupInfo(d: PXkbDescPtr, k: int16): int8 = 
+proc XkbKeyGroupInfo(d: PXkbDescPtr, k: int16): int8 =
   ##define XkbKeyGroupInfo(d,k) (XkbCMKeyGroupInfo((d)->map,(k)))
-  Result = XkbCMKeyGroupInfo(d.map, k)
+  result = XkbCMKeyGroupInfo(d.map, k)
 
-proc XkbKeyNumGroups(d: PXkbDescPtr, k: int16): int8 = 
+proc XkbKeyNumGroups(d: PXkbDescPtr, k: int16): int8 =
   ##define XkbKeyNumGroups(d,k) (XkbCMKeyNumGroups((d)->map,(k)))
-  Result = XkbCMKeyNumGroups(d.map, k)
+  result = XkbCMKeyNumGroups(d.map, k)
 
-proc XkbKeyNumSyms(d: PXkbDescPtr, k: int16): int16 = 
+proc XkbKeyNumSyms(d: PXkbDescPtr, k: int16): int16 =
   ##define XkbKeyNumSyms(d,k) (XkbCMKeyNumSyms((d)->map,(k)))
-  Result = XkbCMKeyNumSyms(d.map, k)
+  result = XkbCMKeyNumSyms(d.map, k)
 
-proc XkbKeySymsPtr*(d: PXkbDescPtr, k: int16): PKeySym = 
+proc XkbKeySymsPtr*(d: PXkbDescPtr, k: int16): PKeySym =
   ##define XkbKeySymsPtr(d,k) (XkbCMKeySymsPtr((d)->map,(k)))
-  Result = XkbCMKeySymsPtr(d.map, k)
+  result = XkbCMKeySymsPtr(d.map, k)
 
-proc XkbKeySym(d: PXkbDescPtr, k: int16, n: int16): TKeySym = 
+proc XkbKeySym(d: PXkbDescPtr, k: int16, n: int16): TKeySym =
   ##define XkbKeySym(d,k,n) (XkbKeySymsPtr(d,k)[n])
-  Result = cast[ptr array[0..0xffff, TKeySym]](XkbKeySymsPtr(d, k))[ze(n)] # XXX: this seems strange!
+  result = cast[ptr array[0..0xffff, TKeySym]](XkbKeySymsPtr(d, k))[ze(n)] # XXX: this seems strange!
 
-proc XkbKeySymEntry(d: PXkbDescPtr, k: int16, sl: int16, g: int8): TKeySym = 
+proc XkbKeySymEntry(d: PXkbDescPtr, k: int16, sl: int16, g: int8): TKeySym =
   ##define XkbKeySymEntry(d,k,sl,g) (XkbKeySym(d,k,((XkbKeyGroupsWidth(d,k)*(g))+(sl))))
-  Result = XkbKeySym(d, k, toU16(ze(XkbKeyGroupsWidth(d, k)) * ze(g) + ze(sl)))
+  result = XkbKeySym(d, k, toU16(ze(XkbKeyGroupsWidth(d, k)) * ze(g) + ze(sl)))
 
-proc XkbKeyAction(d: PXkbDescPtr, k: int16, n: int16): PXkbAction = 
+proc XkbKeyAction(d: PXkbDescPtr, k: int16, n: int16): PXkbAction =
   ##define XkbKeyAction(d,k,n) (XkbKeyHasActions(d,k)?&XkbKeyActionsPtr(d,k)[n]:NULL)
-  #if (XkbKeyHasActions(d, k)): 
-  #  Result = XkbKeyActionsPtr(d, k)[ze(n)] #Buggy !!!
+  #if (XkbKeyHasActions(d, k)):
+  #  result = XkbKeyActionsPtr(d, k)[ze(n)] #Buggy !!!
   assert(false)
   result = nil
-  
-proc XkbKeyActionEntry(d: PXkbDescPtr, k: int16, sl: int16, g: int8): int8 = 
+
+proc XkbKeyActionEntry(d: PXkbDescPtr, k: int16, sl: int16, g: int8): int8 =
   ##define XkbKeyActionEntry(d,k,sl,g) (XkbKeyHasActions(d,k) ?
   #                                      XkbKeyAction(d, k, ((XkbKeyGroupsWidth(d, k) * (g))+(sl))):NULL)
-  if XkbKeyHasActions(d, k): 
-    Result = XkbKeyGroupsWidth(d, k) *% g +% toU8(sl)
-  else: 
-    Result = 0'i8
-  
-proc XkbKeyHasActions(d: PXkbDescPtr, k: int16): bool = 
+  if XkbKeyHasActions(d, k):
+    result = XkbKeyGroupsWidth(d, k) *% g +% toU8(sl)
+  else:
+    result = 0'i8
+
+proc XkbKeyHasActions(d: PXkbDescPtr, k: int16): bool =
   ##define XkbKeyHasActions(d,k) ((d)->server->key_acts[k]!=0)
-  Result = d.server.key_acts[ze(k)] != 0'i16
+  result = d.server.key_acts[ze(k)] != 0'i16
 
-proc XkbKeyNumActions(d: PXkbDescPtr, k: int16): int16 = 
+proc XkbKeyNumActions(d: PXkbDescPtr, k: int16): int16 =
   ##define XkbKeyNumActions(d,k) (XkbKeyHasActions(d,k)?XkbKeyNumSyms(d,k):1)
-  if (XkbKeyHasActions(d, k)): Result = XkbKeyNumSyms(d, k)
-  else: Result = 1'i16
-  
-proc XkbKeyActionsPtr(d: PXkbDescPtr, k: int16): PXkbAction = 
+  if (XkbKeyHasActions(d, k)): result = XkbKeyNumSyms(d, k)
+  else: result = 1'i16
+
+proc XkbKeyActionsPtr(d: PXkbDescPtr, k: int16): PXkbAction =
   ##define XkbKeyActionsPtr(d,k) (XkbSMKeyActionsPtr((d)->server,k))
-  Result = XkbSMKeyActionsPtr(d.server, k)
+  result = XkbSMKeyActionsPtr(d.server, k)
 
-proc XkbKeycodeInRange(d: PXkbDescPtr, k: int16): bool = 
+proc XkbKeycodeInRange(d: PXkbDescPtr, k: int16): bool =
   ##define XkbKeycodeInRange(d,k) (((k)>=(d)->min_key_code)&& ((k)<=(d)->max_key_code))
-  Result = (char(toU8(k)) >= d.min_key_code) and (char(toU8(k)) <= d.max_key_code)
+  result = (char(toU8(k)) >= d.min_key_code) and (char(toU8(k)) <= d.max_key_code)
 
-proc XkbNumKeys(d: PXkbDescPtr): int8 = 
+proc XkbNumKeys(d: PXkbDescPtr): int8 =
   ##define XkbNumKeys(d) ((d)->max_key_code-(d)->min_key_code+1)
-  Result = toU8(ord(d.max_key_code) - ord(d.min_key_code) + 1)
+  result = toU8(ord(d.max_key_code) - ord(d.min_key_code) + 1)
 
-proc XkbXI_DevHasBtnActs(d: PXkbDeviceInfoPtr): bool = 
+proc XkbXI_DevHasBtnActs(d: PXkbDeviceInfoPtr): bool =
   ##define XkbXI_DevHasBtnActs(d) (((d)->num_btns>0)&&((d)->btn_acts!=NULL))
-  Result = (d.num_btns > 0'i16) and (not (d.btn_acts == nil))
+  result = (d.num_btns > 0'i16) and (not (d.btn_acts == nil))
 
-proc XkbXI_LegalDevBtn(d: PXkbDeviceInfoPtr, b: int16): bool = 
+proc XkbXI_LegalDevBtn(d: PXkbDeviceInfoPtr, b: int16): bool =
   ##define XkbXI_LegalDevBtn(d,b) (XkbXI_DevHasBtnActs(d)&&((b)<(d)->num_btns))
-  Result = XkbXI_DevHasBtnActs(d) and (b <% d.num_btns)
+  result = XkbXI_DevHasBtnActs(d) and (b <% d.num_btns)
 
-proc XkbXI_DevHasLeds(d: PXkbDeviceInfoPtr): bool = 
+proc XkbXI_DevHasLeds(d: PXkbDeviceInfoPtr): bool =
   ##define XkbXI_DevHasLeds(d) (((d)->num_leds>0)&&((d)->leds!=NULL))
-  Result = (d.num_leds > 0'i16) and (not (d.leds == nil))
+  result = (d.num_leds > 0'i16) and (not (d.leds == nil))
 
-proc XkbBoundsWidth(b: PXkbBoundsPtr): int16 = 
+proc XkbBoundsWidth(b: PXkbBoundsPtr): int16 =
   ##define XkbBoundsWidth(b) (((b)->x2)-((b)->x1))
-  Result = (b.x2) - b.x1
+  result = (b.x2) - b.x1
 
-proc XkbBoundsHeight(b: PXkbBoundsPtr): int16 = 
+proc XkbBoundsHeight(b: PXkbBoundsPtr): int16 =
   ##define XkbBoundsHeight(b) (((b)->y2)-((b)->y1))
-  Result = (b.y2) - b.y1
+  result = (b.y2) - b.y1
 
-proc XkbOutlineIndex(s: PXkbShapePtr, o: PXkbOutlinePtr): int32 = 
+proc XkbOutlineIndex(s: PXkbShapePtr, o: PXkbOutlinePtr): int32 =
   ##define XkbOutlineIndex(s,o) ((int)((o)-&(s)->outlines[0]))
-  Result = int32((cast[TAddress](o) - cast[TAddress](addr(s.outlines[0]))) div sizeof(PXkbOutlinePtr))
+  result = int32((cast[TAddress](o) - cast[TAddress](addr(s.outlines[0]))) div sizeof(PXkbOutlinePtr))
 
-proc XkbShapeDoodadColor(g: PXkbGeometryPtr, d: PXkbShapeDoodadPtr): PXkbColorPtr = 
+proc XkbShapeDoodadColor(g: PXkbGeometryPtr, d: PXkbShapeDoodadPtr): PXkbColorPtr =
   ##define XkbShapeDoodadColor(g,d) (&(g)->colors[(d)->color_ndx])
-  Result = addr((g.colors[ze(d.color_ndx)]))
+  result = addr((g.colors[ze(d.color_ndx)]))
 
-proc XkbShapeDoodadShape(g: PXkbGeometryPtr, d: PXkbShapeDoodadPtr): PXkbShapePtr = 
+proc XkbShapeDoodadShape(g: PXkbGeometryPtr, d: PXkbShapeDoodadPtr): PXkbShapePtr =
   ##define XkbShapeDoodadShape(g,d) (&(g)->shapes[(d)->shape_ndx])
-  Result = addr(g.shapes[ze(d.shape_ndx)])
+  result = addr(g.shapes[ze(d.shape_ndx)])
 
-proc XkbSetShapeDoodadColor(g: PXkbGeometryPtr, d: PXkbShapeDoodadPtr, 
-                            c: PXkbColorPtr) = 
+proc XkbSetShapeDoodadColor(g: PXkbGeometryPtr, d: PXkbShapeDoodadPtr,
+                            c: PXkbColorPtr) =
   ##define XkbSetShapeDoodadColor(g,d,c) ((d)->color_ndx= (c)-&(g)->colors[0])
   d.color_ndx = toU16((cast[TAddress](c) - cast[TAddress](addr(g.colors[0]))) div sizeof(TXkbColorRec))
 
-proc XkbSetShapeDoodadShape(g: PXkbGeometryPtr, d: PXkbShapeDoodadPtr, 
-                            s: PXkbShapePtr) = 
+proc XkbSetShapeDoodadShape(g: PXkbGeometryPtr, d: PXkbShapeDoodadPtr,
+                            s: PXkbShapePtr) =
   ##define XkbSetShapeDoodadShape(g,d,s) ((d)->shape_ndx= (s)-&(g)->shapes[0])
   d.shape_ndx = toU16((cast[TAddress](s) - cast[TAddress](addr(g.shapes[0]))) div sizeof(TXkbShapeRec))
 
-proc XkbTextDoodadColor(g: PXkbGeometryPtr, d: PXkbTextDoodadPtr): PXkbColorPtr = 
+proc XkbTextDoodadColor(g: PXkbGeometryPtr, d: PXkbTextDoodadPtr): PXkbColorPtr =
   ##define XkbTextDoodadColor(g,d) (&(g)->colors[(d)->color_ndx])
-  Result = addr(g.colors[ze(d.color_ndx)])
+  result = addr(g.colors[ze(d.color_ndx)])
 
-proc XkbSetTextDoodadColor(g: PXkbGeometryPtr, d: PXkbTextDoodadPtr, 
-                           c: PXkbColorPtr) = 
+proc XkbSetTextDoodadColor(g: PXkbGeometryPtr, d: PXkbTextDoodadPtr,
+                           c: PXkbColorPtr) =
   ##define XkbSetTextDoodadColor(g,d,c) ((d)->color_ndx= (c)-&(g)->colors[0])
   d.color_ndx = toU16((cast[TAddress](c) - cast[TAddress](addr(g.colors[0]))) div sizeof(TXkbColorRec))
 
-proc XkbIndicatorDoodadShape(g: PXkbGeometryPtr, d: PXkbIndicatorDoodadPtr): PXkbShapeDoodadPtr = 
+proc XkbIndicatorDoodadShape(g: PXkbGeometryPtr, d: PXkbIndicatorDoodadPtr): PXkbShapeDoodadPtr =
   ##define XkbIndicatorDoodadShape(g,d) (&(g)->shapes[(d)->shape_ndx])
-  Result = cast[PXkbShapeDoodadPtr](addr(g.shapes[ze(d.shape_ndx)]))
+  result = cast[PXkbShapeDoodadPtr](addr(g.shapes[ze(d.shape_ndx)]))
 
-proc XkbIndicatorDoodadOnColor(g: PXkbGeometryPtr, d: PXkbIndicatorDoodadPtr): PXkbColorPtr = 
+proc XkbIndicatorDoodadOnColor(g: PXkbGeometryPtr, d: PXkbIndicatorDoodadPtr): PXkbColorPtr =
   ##define XkbIndicatorDoodadOnColor(g,d) (&(g)->colors[(d)->on_color_ndx])
-  Result = addr(g.colors[ze(d.on_color_ndx)])
+  result = addr(g.colors[ze(d.on_color_ndx)])
 
-proc XkbIndicatorDoodadOffColor(g: PXkbGeometryPtr, d: PXkbIndicatorDoodadPtr): PXkbColorPtr = 
+proc XkbIndicatorDoodadOffColor(g: PXkbGeometryPtr, d: PXkbIndicatorDoodadPtr): PXkbColorPtr =
   ##define XkbIndicatorDoodadOffColor(g,d) (&(g)->colors[(d)->off_color_ndx])
-  Result = addr(g.colors[ze(d.off_color_ndx)])
+  result = addr(g.colors[ze(d.off_color_ndx)])
 
-proc XkbSetIndicatorDoodadOnColor(g: PXkbGeometryPtr, d: PXkbIndicatorDoodadPtr, 
-                                  c: PXkbColorPtr) = 
+proc XkbSetIndicatorDoodadOnColor(g: PXkbGeometryPtr, d: PXkbIndicatorDoodadPtr,
+                                  c: PXkbColorPtr) =
   ##define XkbSetIndicatorDoodadOnColor(g,d,c) ((d)->on_color_ndx= (c)-&(g)->colors[0])
   d.on_color_ndx = toU16((cast[TAddress](c) - cast[TAddress](addr(g.colors[0]))) div sizeof(TXkbColorRec))
 
-proc XkbSetIndicatorDoodadOffColor(g: PXkbGeometryPtr, 
-                                   d: PXkbIndicatorDoodadPtr, c: PXkbColorPtr) = 
+proc XkbSetIndicatorDoodadOffColor(g: PXkbGeometryPtr,
+                                   d: PXkbIndicatorDoodadPtr, c: PXkbColorPtr) =
   ##define        XkbSetIndicatorDoodadOffColor(g,d,c) ((d)->off_color_ndx= (c)-&(g)->colors[0])
   d.off_color_ndx = toU16((cast[TAddress](c) - cast[TAddress](addr(g.colors[0]))) div sizeof(TxkbColorRec))
 
-proc XkbSetIndicatorDoodadShape(g: PXkbGeometryPtr, d: PXkbIndicatorDoodadPtr, 
-                                s: PXkbShapeDoodadPtr) = 
+proc XkbSetIndicatorDoodadShape(g: PXkbGeometryPtr, d: PXkbIndicatorDoodadPtr,
+                                s: PXkbShapeDoodadPtr) =
   ##define XkbSetIndicatorDoodadShape(g,d,s) ((d)->shape_ndx= (s)-&(g)->shapes[0])
   d.shape_ndx = toU16((cast[TAddress](s) - (cast[TAddress](addr(g.shapes[0])))) div sizeof(TXkbShapeRec))
 
-proc XkbLogoDoodadColor(g: PXkbGeometryPtr, d: PXkbLogoDoodadPtr): PXkbColorPtr = 
+proc XkbLogoDoodadColor(g: PXkbGeometryPtr, d: PXkbLogoDoodadPtr): PXkbColorPtr =
   ##define XkbLogoDoodadColor(g,d) (&(g)->colors[(d)->color_ndx])
-  Result = addr(g.colors[ze(d.color_ndx)])
+  result = addr(g.colors[ze(d.color_ndx)])
 
-proc XkbLogoDoodadShape(g: PXkbGeometryPtr, d: PXkbLogoDoodadPtr): PXkbShapeDoodadPtr = 
+proc XkbLogoDoodadShape(g: PXkbGeometryPtr, d: PXkbLogoDoodadPtr): PXkbShapeDoodadPtr =
   ##define XkbLogoDoodadShape(g,d) (&(g)->shapes[(d)->shape_ndx])
-  Result = cast[PXkbShapeDoodadPtr](addr(g.shapes[ze(d.shape_ndx)]))
+  result = cast[PXkbShapeDoodadPtr](addr(g.shapes[ze(d.shape_ndx)]))
 
-proc XkbSetLogoDoodadColor(g: PXkbGeometryPtr, d: PXkbLogoDoodadPtr, 
-                           c: PXkbColorPtr) = 
+proc XkbSetLogoDoodadColor(g: PXkbGeometryPtr, d: PXkbLogoDoodadPtr,
+                           c: PXkbColorPtr) =
   ##define XkbSetLogoDoodadColor(g,d,c) ((d)->color_ndx= (c)-&(g)->colors[0])
   d.color_ndx = toU16((cast[TAddress](c) - cast[TAddress](addr(g.colors[0]))) div sizeof(TXkbColorRec))
 
-proc XkbSetLogoDoodadShape(g: PXkbGeometryPtr, d: PXkbLogoDoodadPtr, 
-                           s: PXkbShapeDoodadPtr) = 
+proc XkbSetLogoDoodadShape(g: PXkbGeometryPtr, d: PXkbLogoDoodadPtr,
+                           s: PXkbShapeDoodadPtr) =
   ##define XkbSetLogoDoodadShape(g,d,s) ((d)->shape_ndx= (s)-&(g)->shapes[0])
   d.shape_ndx = toU16((cast[TAddress](s) - cast[TAddress](addr(g.shapes[0]))) div sizeof(TXkbShapeRec))
 
-proc XkbKeyShape(g: PXkbGeometryPtr, k: PXkbKeyPtr): PXkbShapeDoodadPtr = 
+proc XkbKeyShape(g: PXkbGeometryPtr, k: PXkbKeyPtr): PXkbShapeDoodadPtr =
   ##define XkbKeyShape(g,k) (&(g)->shapes[(k)->shape_ndx])
-  Result = cast[PXkbShapeDoodadPtr](addr(g.shapes[ze(k.shape_ndx)]))
+  result = cast[PXkbShapeDoodadPtr](addr(g.shapes[ze(k.shape_ndx)]))
 
-proc XkbKeyColor(g: PXkbGeometryPtr, k: PXkbKeyPtr): PXkbColorPtr = 
+proc XkbKeyColor(g: PXkbGeometryPtr, k: PXkbKeyPtr): PXkbColorPtr =
   ##define XkbKeyColor(g,k) (&(g)->colors[(k)->color_ndx])
-  Result = addr(g.colors[ze(k.color_ndx)])
+  result = addr(g.colors[ze(k.color_ndx)])
 
-proc XkbSetKeyShape(g: PXkbGeometryPtr, k: PXkbKeyPtr, s: PXkbShapeDoodadPtr) = 
+proc XkbSetKeyShape(g: PXkbGeometryPtr, k: PXkbKeyPtr, s: PXkbShapeDoodadPtr) =
   ##define XkbSetKeyShape(g,k,s) ((k)->shape_ndx= (s)-&(g)->shapes[0])
   k.shape_ndx = toU8((cast[TAddress](s) - cast[TAddress](addr(g.shapes[0]))) div sizeof(TXkbShapeRec))
 
-proc XkbSetKeyColor(g: PXkbGeometryPtr, k: PXkbKeyPtr, c: PXkbColorPtr) = 
+proc XkbSetKeyColor(g: PXkbGeometryPtr, k: PXkbKeyPtr, c: PXkbColorPtr) =
   ##define XkbSetKeyColor(g,k,c) ((k)->color_ndx= (c)-&(g)->colors[0])
   k.color_ndx = toU8((cast[TAddress](c) - cast[TAddress](addr(g.colors[0]))) div sizeof(TxkbColorRec))
 
-proc XkbGeomColorIndex(g: PXkbGeometryPtr, c: PXkbColorPtr): int32 = 
+proc XkbGeomColorIndex(g: PXkbGeometryPtr, c: PXkbColorPtr): int32 =
   ##define XkbGeomColorIndex(g,c) ((int)((c)-&(g)->colors[0]))
-  Result = toU16((cast[TAddress](c) - (cast[TAddress](addr(g.colors[0])))) div sizeof(TxkbColorRec))
+  result = toU16((cast[TAddress](c) - (cast[TAddress](addr(g.colors[0])))) div sizeof(TxkbColorRec))

--- a/src/xkblib.nim
+++ b/src/xkblib.nim
@@ -49,16 +49,16 @@
 #
 #
 
-import 
+import
   X, Xlib, XKB
 
 
 include "x11pragma.nim"
 
 
-type 
+type
   PXkbAnyEvent* = ptr TXkbAnyEvent
-  TXkbAnyEvent*{.final.} = object 
+  TXkbAnyEvent*{.final.} = object
     theType*: int16           # XkbAnyEvent
     serial*: int32            # # of last req processed by server
     send_event*: bool         # is this `from` a SendEvent request?
@@ -66,11 +66,11 @@ type
     time*: TTime              # milliseconds;
     xkb_type*: int16          # XKB event minor code
     device*: int16            # device ID
-  
 
-type 
+
+type
   PXkbNewKeyboardNotifyEvent* = ptr TXkbNewKeyboardNotifyEvent
-  TXkbNewKeyboardNotifyEvent*{.final.} = object 
+  TXkbNewKeyboardNotifyEvent*{.final.} = object
     theType*: int16           # XkbAnyEvent
     serial*: int32            # of last req processed by server
     send_event*: bool         # is this `from` a SendEvent request?
@@ -86,11 +86,11 @@ type
     changed*: int16           # changed aspects of the keyboard
     req_major*: int8          # major and minor opcode of req
     req_minor*: int8          # that caused change, if applicable
-  
 
-type 
+
+type
   PXkbMapNotifyEvent* = ptr TXkbMapNotifyEvent
-  TXkbMapNotifyEvent*{.final.} = object 
+  TXkbMapNotifyEvent*{.final.} = object
     theType*: int16           # XkbAnyEvent
     serial*: int32            # of last req processed by server
     send_event*: bool         # is this `from` a SendEvent request
@@ -117,11 +117,11 @@ type
     num_modmap_keys*: int16
     num_vmodmap_keys*: int16
     vmods*: int16             # mask of changed virtual mods
-  
 
-type 
+
+type
   PXkbStateNotifyEvent* = ptr TXkbStateNotifyEvent
-  TXkbStateNotifyEvent*{.final.} = object 
+  TXkbStateNotifyEvent*{.final.} = object
     theType*: int16           # XkbAnyEvent
     serial*: int32            # # of last req processed by server
     send_event*: bool         # is this `from` a SendEvent request?
@@ -148,11 +148,11 @@ type
     event_type*: int8         # KeyPress or KeyRelease
     req_major*: int8          # Major opcode of request
     req_minor*: int8          # Minor opcode of request
-  
 
-type 
+
+type
   PXkbControlsNotifyEvent* = ptr TXkbControlsNotifyEvent
-  TXkbControlsNotifyEvent*{.final.} = object 
+  TXkbControlsNotifyEvent*{.final.} = object
     theType*: int16           # XkbAnyEvent
     serial*: int32            # of last req processed by server
     send_event*: bool         # is this `from` a SendEvent request?
@@ -168,11 +168,11 @@ type
     event_type*: int8         # type of event that caused change
     req_major*: int8          # if keycode==0, major and minor
     req_minor*: int8          # opcode of req that caused change
-  
 
-type 
+
+type
   PXkbIndicatorNotifyEvent* = ptr TXkbIndicatorNotifyEvent
-  TXkbIndicatorNotifyEvent*{.final.} = object 
+  TXkbIndicatorNotifyEvent*{.final.} = object
     theType*: int16           # XkbAnyEvent
     serial*: int32            # of last req processed by server
     send_event*: bool         # is this `from` a SendEvent request?
@@ -182,11 +182,11 @@ type
     device*: int16            # device
     changed*: int16           # indicators with new state or map
     state*: int16             # current state of all indicators
-  
 
-type 
+
+type
   PXkbNamesNotifyEvent* = ptr TXkbNamesNotifyEvent
-  TXkbNamesNotifyEvent*{.final.} = object 
+  TXkbNamesNotifyEvent*{.final.} = object
     theType*: int16           # XkbAnyEvent
     serial*: int32            # of last req processed by server
     send_event*: bool         # is this `from` a SendEvent request?
@@ -206,11 +206,11 @@ type
     changed_indicators*: int16 # indicators with new names
     first_key*: int16         # first key with new name
     num_keys*: int16          # number of keys with new names
-  
 
-type 
+
+type
   PXkbCompatMapNotifyEvent* = ptr TXkbCompatMapNotifyEvent
-  TXkbCompatMapNotifyEvent*{.final.} = object 
+  TXkbCompatMapNotifyEvent*{.final.} = object
     theType*: int16           # XkbAnyEvent
     serial*: int32            # of last req processed by server
     send_event*: bool         # is this `from` a SendEvent request?
@@ -222,11 +222,11 @@ type
     first_si*: int16          # first new symbol interp
     num_si*: int16            # number of new symbol interps
     num_total_si*: int16      # total # of symbol interps
-  
 
-type 
+
+type
   PXkbBellNotifyEvent* = ptr TXkbBellNotifyEvent
-  TXkbBellNotifyEvent*{.final.} = object 
+  TXkbBellNotifyEvent*{.final.} = object
     theType*: int16           # XkbAnyEvent
     serial*: int32            # of last req processed by server
     send_event*: bool         # is this `from` a SendEvent request?
@@ -242,11 +242,11 @@ type
     name*: TAtom              # "name" of requested bell
     window*: TWindow          # window associated with event
     event_only*: bool         # "event only" requested
-  
 
-type 
+
+type
   PXkbActionMessageEvent* = ptr TXkbActionMessageEvent
-  TXkbActionMessageEvent*{.final.} = object 
+  TXkbActionMessageEvent*{.final.} = object
     theType*: int16           # XkbAnyEvent
     serial*: int32            # of last req processed by server
     send_event*: bool         # is this `from` a SendEvent request?
@@ -259,12 +259,12 @@ type
     key_event_follows*: bool  # true if key event also generated
     group*: int16             # effective group
     mods*: int16              # effective mods
-    message*: array[0..XkbActionMessageLength, Char] # message -- leave space for NUL
-  
+    message*: array[0..XkbActionMessageLength, char] # message -- leave space for NUL
 
-type 
+
+type
   PXkbAccessXNotifyEvent* = ptr TXkbAccessXNotifyEvent
-  TXkbAccessXNotifyEvent*{.final.} = object 
+  TXkbAccessXNotifyEvent*{.final.} = object
     theType*: int16           # XkbAnyEvent
     serial*: int32            # of last req processed by server
     send_event*: bool         # is this `from` a SendEvent request?
@@ -276,11 +276,11 @@ type
     keycode*: int16           # key of event
     sk_delay*: int16          # current slow keys delay
     debounce_delay*: int16    # current debounce delay
-  
 
-type 
+
+type
   PXkbExtensionDeviceNotifyEvent* = ptr TXkbExtensionDeviceNotifyEvent
-  TXkbExtensionDeviceNotifyEvent*{.final.} = object 
+  TXkbExtensionDeviceNotifyEvent*{.final.} = object
     theType*: int16           # XkbAnyEvent
     serial*: int32            # of last req processed by server
     send_event*: bool         # is this `from` a SendEvent request?
@@ -298,11 +298,11 @@ type
     led_state*: int16         # current state of the indicators
     led_class*: int16         # feedback class for led changes
     led_id*: int16            # feedback id for led changes
-  
 
-type 
+
+type
   PXkbEvent* = ptr TXkbEvent
-  TXkbEvent*{.final.} = object 
+  TXkbEvent*{.final.} = object
     theType*: int16
     any*: TXkbAnyEvent
     new_kbd*: TXkbNewKeyboardNotifyEvent
@@ -321,16 +321,16 @@ type
 
 type
   PXkbKbdDpyStatePtr* = ptr TXkbKbdDpyStateRec
-  TXkbKbdDpyStateRec*{.final.} = object  # XkbOpenDisplay error codes 
+  TXkbKbdDpyStateRec*{.final.} = object  # XkbOpenDisplay error codes
 
-const 
+const
   XkbOD_Success* = 0
   XkbOD_BadLibraryVersion* = 1
   XkbOD_ConnectionRefused* = 2
   XkbOD_NonXkbServer* = 3
-  XkbOD_BadServerVersion* = 4 # Values for XlibFlags 
+  XkbOD_BadServerVersion* = 4 # Values for XlibFlags
 
-const 
+const
   XkbLC_ForceLatin1Lookup* = 1 shl 0
   XkbLC_ConsumeLookupMods* = 1 shl 1
   XkbLC_AlwaysConsumeShiftAndLock* = 1 shl 2
@@ -342,24 +342,24 @@ const
   XkbLC_AllComposeControls* = 0xC0000000
   XkbLC_AllControls* = 0xC000001F
 
-proc XkbIgnoreExtension*(ignore: bool): bool{.libx11c, 
+proc XkbIgnoreExtension*(ignore: bool): bool{.libx11c,
     importc: "XkbIgnoreExtension".}
-proc XkbOpenDisplay*(name: cstring, ev_rtrn, err_rtrn, major_rtrn, minor_rtrn, 
+proc XkbOpenDisplay*(name: cstring, ev_rtrn, err_rtrn, major_rtrn, minor_rtrn,
                                     reason: ptr int16): PDisplay{.libx11c, importc: "XkbOpenDisplay".}
-proc XkbQueryExtension*(dpy: PDisplay, opcodeReturn, eventBaseReturn, 
+proc XkbQueryExtension*(dpy: PDisplay, opcodeReturn, eventBaseReturn,
                                        errorBaseReturn, majorRtrn, minorRtrn: ptr int16): bool{.
     libx11c, importc: "XkbQueryExtension".}
 proc XkbUseExtension*(dpy: PDisplay, major_rtrn, minor_rtrn: ptr int16): bool{.
     libx11c, importc: "XkbUseExtension".}
 proc XkbLibraryVersion*(libMajorRtrn, libMinorRtrn: ptr int16): bool{.libx11c, importc: "XkbLibraryVersion".}
 proc XkbSetXlibControls*(dpy: PDisplay, affect, values: int16): int16{.libx11c, importc: "XkbSetXlibControls".}
-proc XkbGetXlibControls*(dpy: PDisplay): int16{.libx11c, 
+proc XkbGetXlibControls*(dpy: PDisplay): int16{.libx11c,
     importc: "XkbGetXlibControls".}
-type 
+type
   TXkbInternAtomFunc* = proc (dpy: PDisplay, name: cstring, only_if_exists: bool): TAtom{.
       cdecl.}
 
-type 
+type
   TXkbGetAtomNameFunc* = proc (dpy: PDisplay, atom: TAtom): cstring{.cdecl.}
 
 proc XkbSetAtomFuncs*(getAtom: TXkbInternAtomFunc, getName: TXkbGetAtomNameFunc){.
@@ -367,55 +367,55 @@ proc XkbSetAtomFuncs*(getAtom: TXkbInternAtomFunc, getName: TXkbGetAtomNameFunc)
 proc XkbKeycodeToKeysym*(dpy: PDisplay, kc: TKeyCode, group, level: int16): TKeySym{.
     libx11c, importc: "XkbKeycodeToKeysym".}
 proc XkbKeysymToModifiers*(dpy: PDisplay, ks: TKeySym): int16{.libx11c, importc: "XkbKeysymToModifiers".}
-proc XkbLookupKeySym*(dpy: PDisplay, keycode: TKeyCode, 
+proc XkbLookupKeySym*(dpy: PDisplay, keycode: TKeyCode,
                       modifiers, modifiers_return: int16, keysym_return: PKeySym): bool{.
     libx11c, importc: "XkbLookupKeySym".}
-proc XkbLookupKeyBinding*(dpy: PDisplay, sym_rtrn: TKeySym, mods: int16, 
+proc XkbLookupKeyBinding*(dpy: PDisplay, sym_rtrn: TKeySym, mods: int16,
                           buffer: cstring, nbytes: int16, extra_rtrn: ptr int16): int16{.
     libx11c, importc: "XkbLookupKeyBinding".}
-proc XkbTranslateKeyCode*(xkb: PXkbDescPtr, keycode: TKeyCode, 
-                          modifiers, modifiers_return: int16, 
-                          keysym_return: PKeySym): bool{.libx11c, 
+proc XkbTranslateKeyCode*(xkb: PXkbDescPtr, keycode: TKeyCode,
+                          modifiers, modifiers_return: int16,
+                          keysym_return: PKeySym): bool{.libx11c,
     importc: "XkbTranslateKeyCode".}
-proc XkbTranslateKeySym*(dpy: PDisplay, sym_return: TKeySym, modifiers: int16, 
+proc XkbTranslateKeySym*(dpy: PDisplay, sym_return: TKeySym, modifiers: int16,
                          buffer: cstring, nbytes: int16, extra_rtrn: ptr int16): int16{.
     libx11c, importc: "XkbTranslateKeySym".}
 proc XkbSetAutoRepeatRate*(dpy: PDisplay, deviceSpec, delay, interval: int16): bool{.
     libx11c, importc: "XkbSetAutoRepeatRate".}
-proc XkbGetAutoRepeatRate*(dpy: PDisplay, deviceSpec: int16, 
+proc XkbGetAutoRepeatRate*(dpy: PDisplay, deviceSpec: int16,
                            delayRtrn, intervalRtrn: PWord): bool{.libx11c, importc: "XkbGetAutoRepeatRate".}
 proc XkbChangeEnabledControls*(dpy: PDisplay, deviceSpec, affect, values: int16): bool{.
     libx11c, importc: "XkbChangeEnabledControls".}
-proc XkbDeviceBell*(dpy: PDisplay, win: TWindow, 
+proc XkbDeviceBell*(dpy: PDisplay, win: TWindow,
                     deviceSpec, bellClass, bellID, percent: int16, name: TAtom): bool{.
     libx11c, importc: "XkbDeviceBell".}
-proc XkbForceDeviceBell*(dpy: PDisplay, 
+proc XkbForceDeviceBell*(dpy: PDisplay,
                          deviceSpec, bellClass, bellID, percent: int16): bool{.
     libx11c, importc: "XkbForceDeviceBell".}
-proc XkbDeviceBellEvent*(dpy: PDisplay, win: TWindow, 
-                         deviceSpec, bellClass, bellID, percent: int16, 
-                         name: TAtom): bool{.libx11c, 
+proc XkbDeviceBellEvent*(dpy: PDisplay, win: TWindow,
+                         deviceSpec, bellClass, bellID, percent: int16,
+                         name: TAtom): bool{.libx11c,
     importc: "XkbDeviceBellEvent".}
 proc XkbBell*(dpy: PDisplay, win: TWindow, percent: int16, name: TAtom): bool{.
     libx11c, importc: "XkbBell".}
-proc XkbForceBell*(dpy: PDisplay, percent: int16): bool{.libx11c, 
+proc XkbForceBell*(dpy: PDisplay, percent: int16): bool{.libx11c,
     importc: "XkbForceBell".}
 proc XkbBellEvent*(dpy: PDisplay, win: TWindow, percent: int16, name: TAtom): bool{.
     libx11c, importc: "XkbBellEvent".}
 proc XkbSelectEvents*(dpy: PDisplay, deviceID, affect, values: int16): bool{.
     libx11c, importc: "XkbSelectEvents".}
-proc XkbSelectEventDetails*(dpy: PDisplay, deviceID, eventType: int16, 
+proc XkbSelectEventDetails*(dpy: PDisplay, deviceID, eventType: int16,
                             affect, details: int32): bool{.libx11c, importc: "XkbSelectEventDetails".}
-proc XkbNoteMapChanges*(old: PXkbMapChangesPtr, new: PXkbMapNotifyEvent, 
-                        wanted: int16){.libx11c, 
+proc XkbNoteMapChanges*(old: PXkbMapChangesPtr, new: PXkbMapNotifyEvent,
+                        wanted: int16){.libx11c,
                                         importc: "XkbNoteMapChanges".}
-proc XkbNoteNameChanges*(old: PXkbNameChangesPtr, new: PXkbNamesNotifyEvent, 
-                         wanted: int16){.libx11c, 
+proc XkbNoteNameChanges*(old: PXkbNameChangesPtr, new: PXkbNamesNotifyEvent,
+                         wanted: int16){.libx11c,
     importc: "XkbNoteNameChanges".}
 proc XkbGetIndicatorState*(dpy: PDisplay, deviceSpec: int16, pStateRtrn: PWord): TStatus{.
     libx11c, importc: "XkbGetIndicatorState".}
-proc XkbGetDeviceIndicatorState*(dpy: PDisplay, 
-                                 deviceSpec, ledClass, ledID: int16, 
+proc XkbGetDeviceIndicatorState*(dpy: PDisplay,
+                                 deviceSpec, ledClass, ledID: int16,
                                  pStateRtrn: PWord): TStatus{.libx11c, importc: "XkbGetDeviceIndicatorState".}
 proc XkbGetIndicatorMap*(dpy: PDisplay, which: int32, desc: PXkbDescPtr): TStatus{.
     libx11c, importc: "XkbGetIndicatorMap".}
@@ -423,27 +423,27 @@ proc XkbSetIndicatorMap*(dpy: PDisplay, which: int32, desc: PXkbDescPtr): bool{.
     libx11c, importc: "XkbSetIndicatorMap".}
 proc XkbNoteIndicatorMapChanges*(o, n: PXkbIndicatorChangesPtr, w: int16)
 proc XkbNoteIndicatorStateChanges*(o, n: PXkbIndicatorChangesPtr, w: int16)
-proc XkbGetIndicatorMapChanges*(d: PDisplay, x: PXkbDescPtr, 
+proc XkbGetIndicatorMapChanges*(d: PDisplay, x: PXkbDescPtr,
                                 c: PXkbIndicatorChangesPtr): TStatus
-proc XkbChangeIndicatorMaps*(d: PDisplay, x: PXkbDescPtr, 
+proc XkbChangeIndicatorMaps*(d: PDisplay, x: PXkbDescPtr,
                              c: PXkbIndicatorChangesPtr): bool
-proc XkbGetNamedIndicator*(dpy: PDisplay, name: TAtom, pNdxRtrn: ptr int16, 
-                           pStateRtrn: ptr bool, pMapRtrn: PXkbIndicatorMapPtr, 
-                           pRealRtrn: ptr bool): bool{.libx11c, 
+proc XkbGetNamedIndicator*(dpy: PDisplay, name: TAtom, pNdxRtrn: ptr int16,
+                           pStateRtrn: ptr bool, pMapRtrn: PXkbIndicatorMapPtr,
+                           pRealRtrn: ptr bool): bool{.libx11c,
     importc: "XkbGetNamedIndicator".}
-proc XkbGetNamedDeviceIndicator*(dpy: PDisplay, 
-                                 deviceSpec, ledClass, ledID: int16, 
-                                 name: TAtom, pNdxRtrn: ptr int16, 
-                                 pStateRtrn: ptr bool, 
-                                 pMapRtrn: PXkbIndicatorMapPtr, 
+proc XkbGetNamedDeviceIndicator*(dpy: PDisplay,
+                                 deviceSpec, ledClass, ledID: int16,
+                                 name: TAtom, pNdxRtrn: ptr int16,
+                                 pStateRtrn: ptr bool,
+                                 pMapRtrn: PXkbIndicatorMapPtr,
                                  pRealRtrn: ptr bool): bool{.libx11c, importc: "XkbGetNamedDeviceIndicator".}
-proc XkbSetNamedIndicator*(dpy: PDisplay, name: TAtom, 
-                           changeState, state, createNewMap: bool, 
+proc XkbSetNamedIndicator*(dpy: PDisplay, name: TAtom,
+                           changeState, state, createNewMap: bool,
                            pMap: PXkbIndicatorMapPtr): bool{.libx11c, importc: "XkbSetNamedIndicator".}
-proc XkbSetNamedDeviceIndicator*(dpy: PDisplay, 
-                                 deviceSpec, ledClass, ledID: int16, 
-                                 name: TAtom, 
-                                 changeState, state, createNewMap: bool, 
+proc XkbSetNamedDeviceIndicator*(dpy: PDisplay,
+                                 deviceSpec, ledClass, ledID: int16,
+                                 name: TAtom,
+                                 changeState, state, createNewMap: bool,
                                  pMap: PXkbIndicatorMapPtr): bool{.libx11c, importc: "XkbSetNamedDeviceIndicator".}
 proc XkbLockModifiers*(dpy: PDisplay, deviceSpec, affect, values: int16): bool{.
     libx11c, importc: "XkbLockModifiers".}
@@ -451,19 +451,19 @@ proc XkbLatchModifiers*(dpy: PDisplay, deviceSpec, affect, values: int16): bool{
     libx11c, importc: "XkbLatchModifiers".}
 proc XkbLockGroup*(dpy: PDisplay, deviceSpec, group: int16): bool{.libx11c, importc: "XkbLockGroup".}
 proc XkbLatchGroup*(dpy: PDisplay, deviceSpec, group: int16): bool{.libx11c, importc: "XkbLatchGroup".}
-proc XkbSetServerInternalMods*(dpy: PDisplay, deviceSpec, affectReal, 
+proc XkbSetServerInternalMods*(dpy: PDisplay, deviceSpec, affectReal,
     realValues, affectVirtual, virtualValues: int16): bool{.libx11c, importc: "XkbSetServerInternalMods".}
-proc XkbSetIgnoreLockMods*(dpy: PDisplay, deviceSpec, affectReal, realValues, 
-    affectVirtual, virtualValues: int16): bool{.libx11c, 
+proc XkbSetIgnoreLockMods*(dpy: PDisplay, deviceSpec, affectReal, realValues,
+    affectVirtual, virtualValues: int16): bool{.libx11c,
     importc: "XkbSetIgnoreLockMods".}
 proc XkbVirtualModsToReal*(dpy: PDisplay, virtual_mask: int16, mask_rtrn: PWord): bool{.
     libx11c, importc: "XkbVirtualModsToReal".}
-proc XkbComputeEffectiveMap*(xkb: PXkbDescPtr, theType: PXkbKeyTypePtr, 
-                             map_rtrn: PByte): bool{.libx11c, 
+proc XkbComputeEffectiveMap*(xkb: PXkbDescPtr, theType: PXkbKeyTypePtr,
+                             map_rtrn: PByte): bool{.libx11c,
     importc: "XkbComputeEffectiveMap".}
 proc XkbInitCanonicalKeyTypes*(xkb: PXkbDescPtr, which: int16, keypadVMod: int16): TStatus{.
     libx11c, importc: "XkbInitCanonicalKeyTypes".}
-proc XkbAllocKeyboard*(): PXkbDescPtr{.libx11c, 
+proc XkbAllocKeyboard*(): PXkbDescPtr{.libx11c,
                                        importc: "XkbAllocKeyboard".}
 proc XkbFreeKeyboard*(xkb: PXkbDescPtr, which: int16, freeDesc: bool){.libx11c, importc: "XkbFreeKeyboard".}
 proc XkbAllocClientMap*(xkb: PXkbDescPtr, which, nTypes: int16): TStatus{.libx11c, importc: "XkbAllocClientMap".}
@@ -471,17 +471,17 @@ proc XkbAllocServerMap*(xkb: PXkbDescPtr, which, nActions: int16): TStatus{.
     libx11c, importc: "XkbAllocServerMap".}
 proc XkbFreeClientMap*(xkb: PXkbDescPtr, what: int16, freeMap: bool){.libx11c, importc: "XkbFreeClientMap".}
 proc XkbFreeServerMap*(xkb: PXkbDescPtr, what: int16, freeMap: bool){.libx11c, importc: "XkbFreeServerMap".}
-proc XkbAddKeyType*(xkb: PXkbDescPtr, name: TAtom, map_count: int16, 
+proc XkbAddKeyType*(xkb: PXkbDescPtr, name: TAtom, map_count: int16,
                     want_preserve: bool, num_lvls: int16): PXkbKeyTypePtr{.
     libx11c, importc: "XkbAddKeyType".}
-proc XkbAllocIndicatorMaps*(xkb: PXkbDescPtr): TStatus{.libx11c, 
+proc XkbAllocIndicatorMaps*(xkb: PXkbDescPtr): TStatus{.libx11c,
     importc: "XkbAllocIndicatorMaps".}
-proc XkbFreeIndicatorMaps*(xkb: PXkbDescPtr){.libx11c, 
+proc XkbFreeIndicatorMaps*(xkb: PXkbDescPtr){.libx11c,
     importc: "XkbFreeIndicatorMaps".}
 proc XkbGetMap*(dpy: PDisplay, which, deviceSpec: int16): PXkbDescPtr{.libx11c, importc: "XkbGetMap".}
 proc XkbGetUpdatedMap*(dpy: PDisplay, which: int16, desc: PXkbDescPtr): TStatus{.
     libx11c, importc: "XkbGetUpdatedMap".}
-proc XkbGetMapChanges*(dpy: PDisplay, xkb: PXkbDescPtr, 
+proc XkbGetMapChanges*(dpy: PDisplay, xkb: PXkbDescPtr,
                        changes: PXkbMapChangesPtr): TStatus{.libx11c, importc: "XkbGetMapChanges".}
 proc XkbRefreshKeyboardMapping*(event: PXkbMapNotifyEvent): TStatus{.libx11c, importc: "XkbRefreshKeyboardMapping".}
 proc XkbGetKeyTypes*(dpy: PDisplay, first, num: int16, xkb: PXkbDescPtr): TStatus{.
@@ -490,15 +490,15 @@ proc XkbGetKeySyms*(dpy: PDisplay, first, num: int16, xkb: PXkbDescPtr): TStatus
     libx11c, importc: "XkbGetKeySyms".}
 proc XkbGetKeyActions*(dpy: PDisplay, first, num: int16, xkb: PXkbDescPtr): TStatus{.
     libx11c, importc: "XkbGetKeyActions".}
-proc XkbGetKeyBehaviors*(dpy: PDisplay, firstKey, nKeys: int16, 
-                         desc: PXkbDescPtr): TStatus{.libx11c, 
+proc XkbGetKeyBehaviors*(dpy: PDisplay, firstKey, nKeys: int16,
+                         desc: PXkbDescPtr): TStatus{.libx11c,
     importc: "XkbGetKeyBehaviors".}
 proc XkbGetVirtualMods*(dpy: PDisplay, which: int16, desc: PXkbDescPtr): TStatus{.
     libx11c, importc: "XkbGetVirtualMods".}
-proc XkbGetKeyExplicitComponents*(dpy: PDisplay, firstKey, nKeys: int16, 
+proc XkbGetKeyExplicitComponents*(dpy: PDisplay, firstKey, nKeys: int16,
                                   desc: PXkbDescPtr): TStatus{.libx11c, importc: "XkbGetKeyExplicitComponents".}
-proc XkbGetKeyModifierMap*(dpy: PDisplay, firstKey, nKeys: int16, 
-                           desc: PXkbDescPtr): TStatus{.libx11c, 
+proc XkbGetKeyModifierMap*(dpy: PDisplay, firstKey, nKeys: int16,
+                           desc: PXkbDescPtr): TStatus{.libx11c,
     importc: "XkbGetKeyModifierMap".}
 proc XkbAllocControls*(xkb: PXkbDescPtr, which: int16): TStatus{.libx11c, importc: "XkbAllocControls".}
 proc XkbFreeControls*(xkb: PXkbDescPtr, which: int16, freeMap: bool){.libx11c, importc: "XkbFreeControls".}
@@ -506,10 +506,10 @@ proc XkbGetControls*(dpy: PDisplay, which: int32, desc: PXkbDescPtr): TStatus{.
     libx11c, importc: "XkbGetControls".}
 proc XkbSetControls*(dpy: PDisplay, which: int32, desc: PXkbDescPtr): bool{.
     libx11c, importc: "XkbSetControls".}
-proc XkbNoteControlsChanges*(old: PXkbControlsChangesPtr, 
+proc XkbNoteControlsChanges*(old: PXkbControlsChangesPtr,
                              new: PXkbControlsNotifyEvent, wanted: int16){.
     libx11c, importc: "XkbNoteControlsChanges".}
-proc XkbGetControlsChanges*(d: PDisplay, x: PXkbDescPtr, 
+proc XkbGetControlsChanges*(d: PDisplay, x: PXkbDescPtr,
                             c: PXkbControlsChangesPtr): TStatus
 proc XkbChangeControls*(d: PDisplay, x: PXkbDescPtr, c: PXkbControlsChangesPtr): bool
 proc XkbAllocCompatMap*(xkb: PXkbDescPtr, which, nInterpret: int16): TStatus{.
@@ -517,21 +517,21 @@ proc XkbAllocCompatMap*(xkb: PXkbDescPtr, which, nInterpret: int16): TStatus{.
 proc XkbFreeCompatMap*(xkib: PXkbDescPtr, which: int16, freeMap: bool){.libx11c, importc: "XkbFreeCompatMap".}
 proc XkbGetCompatMap*(dpy: PDisplay, which: int16, xkb: PXkbDescPtr): TStatus{.
     libx11c, importc: "XkbGetCompatMap".}
-proc XkbSetCompatMap*(dpy: PDisplay, which: int16, xkb: PXkbDescPtr, 
-                      updateActions: bool): bool{.libx11c, 
+proc XkbSetCompatMap*(dpy: PDisplay, which: int16, xkb: PXkbDescPtr,
+                      updateActions: bool): bool{.libx11c,
     importc: "XkbSetCompatMap".}
-proc XkbAddSymInterpret*(xkb: PXkbDescPtr, si: PXkbSymInterpretPtr, 
+proc XkbAddSymInterpret*(xkb: PXkbDescPtr, si: PXkbSymInterpretPtr,
                          updateMap: bool, changes: PXkbChangesPtr): PXkbSymInterpretPtr{.
     libx11c, importc: "XkbAddSymInterpret".}
-proc XkbAllocNames*(xkb: PXkbDescPtr, which: int16, 
+proc XkbAllocNames*(xkb: PXkbDescPtr, which: int16,
                     nTotalRG, nTotalAliases: int16): TStatus{.libx11c, importc: "XkbAllocNames".}
 proc XkbGetNames*(dpy: PDisplay, which: int16, desc: PXkbDescPtr): TStatus{.
     libx11c, importc: "XkbGetNames".}
-proc XkbSetNames*(dpy: PDisplay, which, firstType, nTypes: int16, 
-                  desc: PXkbDescPtr): bool{.libx11c, 
+proc XkbSetNames*(dpy: PDisplay, which, firstType, nTypes: int16,
+                  desc: PXkbDescPtr): bool{.libx11c,
     importc: "XkbSetNames".}
-proc XkbChangeNames*(dpy: PDisplay, xkb: PXkbDescPtr, 
-                     changes: PXkbNameChangesPtr): bool{.libx11c, 
+proc XkbChangeNames*(dpy: PDisplay, xkb: PXkbDescPtr,
+                     changes: PXkbNameChangesPtr): bool{.libx11c,
     importc: "XkbChangeNames".}
 proc XkbFreeNames*(xkb: PXkbDescPtr, which: int16, freeMap: bool){.libx11c, importc: "XkbFreeNames".}
 proc XkbGetState*(dpy: PDisplay, deviceSpec: int16, rtrnState: PXkbStatePtr): TStatus{.
@@ -539,11 +539,11 @@ proc XkbGetState*(dpy: PDisplay, deviceSpec: int16, rtrnState: PXkbStatePtr): TS
 proc XkbSetMap*(dpy: PDisplay, which: int16, desc: PXkbDescPtr): bool{.libx11c, importc: "XkbSetMap".}
 proc XkbChangeMap*(dpy: PDisplay, desc: PXkbDescPtr, changes: PXkbMapChangesPtr): bool{.
     libx11c, importc: "XkbChangeMap".}
-proc XkbSetDetectableAutoRepeat*(dpy: PDisplay, detectable: bool, 
+proc XkbSetDetectableAutoRepeat*(dpy: PDisplay, detectable: bool,
                                  supported: ptr bool): bool{.libx11c, importc: "XkbSetDetectableAutoRepeat".}
 proc XkbGetDetectableAutoRepeat*(dpy: PDisplay, supported: ptr bool): bool{.
     libx11c, importc: "XkbGetDetectableAutoRepeat".}
-proc XkbSetAutoResetControls*(dpy: PDisplay, changes: int16, 
+proc XkbSetAutoResetControls*(dpy: PDisplay, changes: int16,
                               auto_ctrls, auto_values: PWord): bool{.libx11c, importc: "XkbSetAutoResetControls".}
 proc XkbGetAutoResetControls*(dpy: PDisplay, auto_ctrls, auto_ctrl_values: PWord): bool{.
     libx11c, importc: "XkbGetAutoResetControls".}
@@ -553,44 +553,44 @@ proc XkbGetPerClientControls*(dpy: PDisplay, ctrls: PWord): bool{.libx11c, impor
 proc XkbCopyKeyType*(`from`, into: PXkbKeyTypePtr): TStatus{.libx11c, importc: "XkbCopyKeyType".}
 proc XkbCopyKeyTypes*(`from`, into: PXkbKeyTypePtr, num_types: int16): TStatus{.
     libx11c, importc: "XkbCopyKeyTypes".}
-proc XkbResizeKeyType*(xkb: PXkbDescPtr, type_ndx, map_count: int16, 
+proc XkbResizeKeyType*(xkb: PXkbDescPtr, type_ndx, map_count: int16,
                        want_preserve: bool, new_num_lvls: int16): TStatus{.
     libx11c, importc: "XkbResizeKeyType".}
 proc XkbResizeKeySyms*(desc: PXkbDescPtr, forKey, symsNeeded: int16): PKeySym{.
     libx11c, importc: "XkbResizeKeySyms".}
 proc XkbResizeKeyActions*(desc: PXkbDescPtr, forKey, actsNeeded: int16): PXkbAction{.
     libx11c, importc: "XkbResizeKeyActions".}
-proc XkbChangeTypesOfKey*(xkb: PXkbDescPtr, key, num_groups: int16, 
-                          groups: int16, newTypes: ptr int16, 
+proc XkbChangeTypesOfKey*(xkb: PXkbDescPtr, key, num_groups: int16,
+                          groups: int16, newTypes: ptr int16,
                           pChanges: PXkbMapChangesPtr): TStatus{.libx11c, importc: "XkbChangeTypesOfKey".}
-    
-proc XkbListComponents*(dpy: PDisplay, deviceSpec: int16, 
+
+proc XkbListComponents*(dpy: PDisplay, deviceSpec: int16,
                         ptrns: PXkbComponentNamesPtr, max_inout: ptr int16): PXkbComponentListPtr{.
     libx11c, importc: "XkbListComponents".}
-proc XkbFreeComponentList*(list: PXkbComponentListPtr){.libx11c, 
+proc XkbFreeComponentList*(list: PXkbComponentListPtr){.libx11c,
     importc: "XkbFreeComponentList".}
 proc XkbGetKeyboard*(dpy: PDisplay, which, deviceSpec: int16): PXkbDescPtr{.
     libx11c, importc: "XkbGetKeyboard".}
-proc XkbGetKeyboardByName*(dpy: PDisplay, deviceSpec: int16, 
-                           names: PXkbComponentNamesPtr, want, need: int16, 
-                           load: bool): PXkbDescPtr{.libx11c, 
+proc XkbGetKeyboardByName*(dpy: PDisplay, deviceSpec: int16,
+                           names: PXkbComponentNamesPtr, want, need: int16,
+                           load: bool): PXkbDescPtr{.libx11c,
     importc: "XkbGetKeyboardByName".}
-    
-proc XkbKeyTypesForCoreSymbols*(xkb: PXkbDescPtr, 
+
+proc XkbKeyTypesForCoreSymbols*(xkb: PXkbDescPtr,
                                 map_width: int16,  # keyboard device
                                 core_syms: PKeySym,  # always mapWidth symbols
                                 protected: int16,  # explicit key types
                                 types_inout: ptr int16,  # always four type indices
                                 xkb_syms_rtrn: PKeySym): int16{.libx11c, importc: "XkbKeyTypesForCoreSymbols".}
   # must have enough space
-proc XkbApplyCompatMapToKey*(xkb: PXkbDescPtr,  
+proc XkbApplyCompatMapToKey*(xkb: PXkbDescPtr,
                              key: TKeyCode,  # key to be updated
                              changes: PXkbChangesPtr): bool{.libx11c, importc: "XkbApplyCompatMapToKey".}
   # resulting changes to map
-proc XkbUpdateMapFromCore*(xkb: PXkbDescPtr,  
+proc XkbUpdateMapFromCore*(xkb: PXkbDescPtr,
                            first_key: TKeyCode,  # first changed key
                            num_keys,
-                           map_width: int16, 
+                           map_width: int16,
                            core_keysyms: PKeySym,  # symbols `from` core keymap
                            changes: PXkbChangesPtr): bool{.libx11c, importc: "XkbUpdateMapFromCore".}
 
@@ -602,60 +602,60 @@ proc XkbAllocDeviceInfo*(deviceSpec, nButtons, szLeds: int16): PXkbDeviceInfoPtr
     libx11c, importc: "XkbAllocDeviceInfo".}
 proc XkbFreeDeviceInfo*(devi: PXkbDeviceInfoPtr, which: int16, freeDevI: bool){.
     libx11c, importc: "XkbFreeDeviceInfo".}
-proc XkbNoteDeviceChanges*(old: PXkbDeviceChangesPtr, 
+proc XkbNoteDeviceChanges*(old: PXkbDeviceChangesPtr,
                            new: PXkbExtensionDeviceNotifyEvent, wanted: int16){.
     libx11c, importc: "XkbNoteDeviceChanges".}
 proc XkbGetDeviceInfo*(dpy: PDisplay, which, deviceSpec, ledClass, ledID: int16): PXkbDeviceInfoPtr{.
     libx11c, importc: "XkbGetDeviceInfo".}
-proc XkbGetDeviceInfoChanges*(dpy: PDisplay, devi: PXkbDeviceInfoPtr, 
+proc XkbGetDeviceInfoChanges*(dpy: PDisplay, devi: PXkbDeviceInfoPtr,
                               changes: PXkbDeviceChangesPtr): TStatus{.libx11c, importc: "XkbGetDeviceInfoChanges".}
-proc XkbGetDeviceButtonActions*(dpy: PDisplay, devi: PXkbDeviceInfoPtr, 
+proc XkbGetDeviceButtonActions*(dpy: PDisplay, devi: PXkbDeviceInfoPtr,
                                 all: bool, first, nBtns: int16): TStatus{.libx11c, importc: "XkbGetDeviceButtonActions".}
-proc XkbGetDeviceLedInfo*(dpy: PDisplay, devi: PXkbDeviceInfoPtr, 
+proc XkbGetDeviceLedInfo*(dpy: PDisplay, devi: PXkbDeviceInfoPtr,
                           ledClass, ledId, which: int16): TStatus{.libx11c, importc: "XkbGetDeviceLedInfo".}
 proc XkbSetDeviceInfo*(dpy: PDisplay, which: int16, devi: PXkbDeviceInfoPtr): bool{.
     libx11c, importc: "XkbSetDeviceInfo".}
-proc XkbChangeDeviceInfo*(dpy: PDisplay, desc: PXkbDeviceInfoPtr, 
+proc XkbChangeDeviceInfo*(dpy: PDisplay, desc: PXkbDeviceInfoPtr,
                           changes: PXkbDeviceChangesPtr): bool{.libx11c, importc: "XkbChangeDeviceInfo".}
-proc XkbSetDeviceLedInfo*(dpy: PDisplay, devi: PXkbDeviceInfoPtr, 
+proc XkbSetDeviceLedInfo*(dpy: PDisplay, devi: PXkbDeviceInfoPtr,
                           ledClass, ledID, which: int16): bool{.libx11c, importc: "XkbSetDeviceLedInfo".}
-proc XkbSetDeviceButtonActions*(dpy: PDisplay, devi: PXkbDeviceInfoPtr, 
+proc XkbSetDeviceButtonActions*(dpy: PDisplay, devi: PXkbDeviceInfoPtr,
                                 first, nBtns: int16): bool{.libx11c, importc: "XkbSetDeviceButtonActions".}
 
-proc XkbToControl*(c: int8): int8{.libx11c, 
+proc XkbToControl*(c: int8): int8{.libx11c,
                                    importc: "XkbToControl".}
 
-proc XkbSetDebuggingFlags*(dpy: PDisplay, mask, flags: int16, msg: cstring, 
+proc XkbSetDebuggingFlags*(dpy: PDisplay, mask, flags: int16, msg: cstring,
                            ctrls_mask, ctrls, rtrn_flags, rtrn_ctrls: int16): bool{.
     libx11c, importc: "XkbSetDebuggingFlags".}
-proc XkbApplyVirtualModChanges*(xkb: PXkbDescPtr, changed: int16, 
+proc XkbApplyVirtualModChanges*(xkb: PXkbDescPtr, changed: int16,
                                 changes: PXkbChangesPtr): bool{.libx11c, importc: "XkbApplyVirtualModChanges".}
 
 # implementation
 
-proc XkbNoteIndicatorMapChanges(o, n: PXkbIndicatorChangesPtr, w: int16) = 
+proc XkbNoteIndicatorMapChanges(o, n: PXkbIndicatorChangesPtr, w: int16) =
   ##define XkbNoteIndicatorMapChanges(o,n,w) ((o)->map_changes|=((n)->map_changes&(w)))
   o.map_changes = o.map_changes or (n.map_changes and w)
 
-proc XkbNoteIndicatorStateChanges(o, n: PXkbIndicatorChangesPtr, w: int16) = 
+proc XkbNoteIndicatorStateChanges(o, n: PXkbIndicatorChangesPtr, w: int16) =
   ##define XkbNoteIndicatorStateChanges(o,n,w) ((o)->state_changes|=((n)->state_changes&(w)))
   o.state_changes = o.state_changes or (n.state_changes and (w))
 
-proc XkbGetIndicatorMapChanges(d: PDisplay, x: PXkbDescPtr, 
-                               c: PXkbIndicatorChangesPtr): TStatus = 
+proc XkbGetIndicatorMapChanges(d: PDisplay, x: PXkbDescPtr,
+                               c: PXkbIndicatorChangesPtr): TStatus =
   ##define XkbGetIndicatorMapChanges(d,x,c) (XkbGetIndicatorMap((d),(c)->map_changes,x)
-  Result = XkbGetIndicatorMap(d, c.map_changes, x)
+  result = XkbGetIndicatorMap(d, c.map_changes, x)
 
-proc XkbChangeIndicatorMaps(d: PDisplay, x: PXkbDescPtr, 
-                            c: PXkbIndicatorChangesPtr): bool = 
+proc XkbChangeIndicatorMaps(d: PDisplay, x: PXkbDescPtr,
+                            c: PXkbIndicatorChangesPtr): bool =
   ##define XkbChangeIndicatorMaps(d,x,c) (XkbSetIndicatorMap((d),(c)->map_changes,x))
-  Result = XkbSetIndicatorMap(d, c.map_changes, x)
+  result = XkbSetIndicatorMap(d, c.map_changes, x)
 
-proc XkbGetControlsChanges(d: PDisplay, x: PXkbDescPtr, 
-                           c: PXkbControlsChangesPtr): TStatus = 
+proc XkbGetControlsChanges(d: PDisplay, x: PXkbDescPtr,
+                           c: PXkbControlsChangesPtr): TStatus =
   ##define XkbGetControlsChanges(d,x,c) XkbGetControls(d,(c)->changed_ctrls,x)
-  Result = XkbGetControls(d, c.changed_ctrls, x)
+  result = XkbGetControls(d, c.changed_ctrls, x)
 
-proc XkbChangeControls(d: PDisplay, x: PXkbDescPtr, c: PXkbControlsChangesPtr): bool = 
+proc XkbChangeControls(d: PDisplay, x: PXkbDescPtr, c: PXkbControlsChangesPtr): bool =
   ##define XkbChangeControls(d,x,c) XkbSetControls(d,(c)->changed_ctrls,x)
-  Result = XkbSetControls(d, c.changed_ctrls, x)
+  result = XkbSetControls(d, c.changed_ctrls, x)

--- a/src/xvlib.nim
+++ b/src/xvlib.nim
@@ -4,13 +4,13 @@
 #
 #                        All Rights Reserved
 #
-#Permission to use, copy, modify, and distribute this software and its 
-#documentation for any purpose and without fee is hereby granted, 
+#Permission to use, copy, modify, and distribute this software and its
+#documentation for any purpose and without fee is hereby granted,
 #provided that the above copyright notice appear in all copies and that
-#both that copyright notice and this permission notice appear in 
+#both that copyright notice and this permission notice appear in
 #supporting documentation, and that the names of Digital or MIT not be
 #used in advertising or publicity pertaining to distribution of the
-#software without specific, written prior permission.  
+#software without specific, written prior permission.
 #
 #DIGITAL DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING
 #ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO EVENT SHALL
@@ -21,13 +21,13 @@
 #SOFTWARE.
 #
 #******************************************************************
-# $XFree86: xc/include/extensions/Xvlib.h,v 1.3 1999/12/11 19:28:48 mvojkovi Exp $ 
+# $XFree86: xc/include/extensions/Xvlib.h,v 1.3 1999/12/11 19:28:48 mvojkovi Exp $
 #*
-#** File: 
+#** File:
 #**
 #**   Xvlib.h --- Xv library public header file
 #**
-#** Author: 
+#** Author:
 #**
 #**   David Carver (Digital Workstation Engineering/Project Athena)
 #**
@@ -50,28 +50,28 @@
 #**
 #*
 
-import 
+import
   x, xlib, xshm, xv
 
-const 
+const
   libXv* = "libXv.so"
 
-type 
+type
   PXvRational* = ptr TXvRational
-  TXvRational*{.final.} = object 
+  TXvRational*{.final.} = object
     numerator*: cint
     denominator*: cint
 
   PXvAttribute* = ptr TXvAttribute
-  TXvAttribute*{.final.} = object 
-    flags*: cint              # XvGettable, XvSettable 
+  TXvAttribute*{.final.} = object
+    flags*: cint              # XvGettable, XvSettable
     min_value*: cint
     max_value*: cint
     name*: cstring
 
   PPXvEncodingInfo* = ptr PXvEncodingInfo
   PXvEncodingInfo* = ptr TXvEncodingInfo
-  TXvEncodingInfo*{.final.} = object 
+  TXvEncodingInfo*{.final.} = object
     encoding_id*: TXvEncodingID
     name*: cstring
     width*: culong
@@ -80,13 +80,13 @@ type
     num_encodings*: culong
 
   PXvFormat* = ptr TXvFormat
-  TXvFormat*{.final.} = object 
+  TXvFormat*{.final.} = object
     depth*: cchar
     visual_id*: culong
 
   PPXvAdaptorInfo* = ptr PXvAdaptorInfo
   PXvAdaptorInfo* = ptr TXvAdaptorInfo
-  TXvAdaptorInfo*{.final.} = object 
+  TXvAdaptorInfo*{.final.} = object
     base_id*: TXvPortID
     num_ports*: culong
     thetype*: cchar
@@ -96,29 +96,29 @@ type
     num_adaptors*: culong
 
   PXvVideoNotifyEvent* = ptr TXvVideoNotifyEvent
-  TXvVideoNotifyEvent*{.final.} = object 
+  TXvVideoNotifyEvent*{.final.} = object
     theType*: cint
-    serial*: culong           # # of last request processed by server 
-    send_event*: TBool        # true if this came from a SendEvent request 
-    display*: PDisplay        # Display the event was read from 
-    drawable*: TDrawable      # drawable 
-    reason*: culong           # what generated this event 
-    port_id*: TXvPortID       # what port 
-    time*: TTime              # milliseconds 
-  
+    serial*: culong           # # of last request processed by server
+    send_event*: TBool        # true if this came from a SendEvent request
+    display*: PDisplay        # Display the event was read from
+    drawable*: TDrawable      # drawable
+    reason*: culong           # what generated this event
+    port_id*: TXvPortID       # what port
+    time*: TTime              # milliseconds
+
   PXvPortNotifyEvent* = ptr TXvPortNotifyEvent
-  TXvPortNotifyEvent*{.final.} = object 
+  TXvPortNotifyEvent*{.final.} = object
     theType*: cint
-    serial*: culong           # # of last request processed by server 
-    send_event*: TBool        # true if this came from a SendEvent request 
-    display*: PDisplay        # Display the event was read from 
-    port_id*: TXvPortID       # what port 
-    time*: TTime              # milliseconds 
-    attribute*: TAtom         # atom that identifies attribute 
-    value*: clong             # value of attribute 
-  
+    serial*: culong           # # of last request processed by server
+    send_event*: TBool        # true if this came from a SendEvent request
+    display*: PDisplay        # Display the event was read from
+    port_id*: TXvPortID       # what port
+    time*: TTime              # milliseconds
+    attribute*: TAtom         # atom that identifies attribute
+    value*: clong             # value of attribute
+
   PXvEvent* = ptr TXvEvent
-  TXvEvent*{.final.} = object 
+  TXvEvent*{.final.} = object
     pad*: array[0..23, clong] #case longint of
                               #      0 : (
                               #            theType : cint;
@@ -130,22 +130,22 @@ type
                               #            xvport : TXvPortNotifyEvent;
                               #          );
                               #      3 : (
-                              #            
+                              #
                               #          );
-  
+
   PXvImageFormatValues* = ptr TXvImageFormatValues
-  TXvImageFormatValues*{.final.} = object 
-    id*: cint                 # Unique descriptor for the format 
-    theType*: cint            # XvRGB, XvYUV 
-    byte_order*: cint         # LSBFirst, MSBFirst 
-    guid*: array[0..15, cchar] # Globally Unique IDentifier 
+  TXvImageFormatValues*{.final.} = object
+    id*: cint                 # Unique descriptor for the format
+    theType*: cint            # XvRGB, XvYUV
+    byte_order*: cint         # LSBFirst, MSBFirst
+    guid*: array[0..15, cchar] # Globally Unique IDentifier
     bits_per_pixel*: cint
-    format*: cint             # XvPacked, XvPlanar 
-    num_planes*: cint         # for RGB formats only 
+    format*: cint             # XvPacked, XvPlanar
+    num_planes*: cint         # for RGB formats only
     depth*: cint
     red_mask*: cuint
     green_mask*: cuint
-    blue_mask*: cuint         # for YUV formats only 
+    blue_mask*: cuint         # for YUV formats only
     y_sample_bits*: cuint
     u_sample_bits*: cuint
     v_sample_bits*: cuint
@@ -155,44 +155,44 @@ type
     vert_y_period*: cuint
     vert_u_period*: cuint
     vert_v_period*: cuint
-    component_order*: array[0..31, char] # eg. UYVY 
-    scanline_order*: cint     # XvTopToBottom, XvBottomToTop 
-  
+    component_order*: array[0..31, char] # eg. UYVY
+    scanline_order*: cint     # XvTopToBottom, XvBottomToTop
+
   PXvImage* = ptr TXvImage
-  TXvImage*{.final.} = object 
+  TXvImage*{.final.} = object
     id*: cint
     width*, height*: cint
-    data_size*: cint          # bytes 
+    data_size*: cint          # bytes
     num_planes*: cint
-    pitches*: pcint           # bytes 
-    offsets*: pcint           # bytes 
+    pitches*: cint           # bytes
+    offsets*: cint           # bytes
     data*: pointer
     obdata*: TXPointer
 
 
-proc XvQueryExtension*(display: PDisplay, p_version, p_revision, p_requestBase, 
-    p_eventBase, p_errorBase: pcuint): cint{.cdecl, dynlib: libXv, importc.}
-proc XvQueryAdaptors*(display: PDisplay, window: TWindow, p_nAdaptors: pcuint, 
-                      p_pAdaptors: PPXvAdaptorInfo): cint{.cdecl, dynlib: libXv, 
+proc XvQueryExtension*(display: PDisplay, p_version, p_revision, p_requestBase,
+    p_eventBase, p_errorBase: cuint): cint{.cdecl, dynlib: libXv, importc.}
+proc XvQueryAdaptors*(display: PDisplay, window: TWindow, p_nAdaptors: cuint,
+                      p_pAdaptors: PPXvAdaptorInfo): cint{.cdecl, dynlib: libXv,
     importc.}
-proc XvQueryEncodings*(display: PDisplay, port: TXvPortID, p_nEncoding: pcuint, 
-                       p_pEncoding: PPXvEncodingInfo): cint{.cdecl, 
+proc XvQueryEncodings*(display: PDisplay, port: TXvPortID, p_nEncoding: cuint,
+                       p_pEncoding: PPXvEncodingInfo): cint{.cdecl,
     dynlib: libXv, importc.}
-proc XvPutVideo*(display: PDisplay, port: TXvPortID, d: TDrawable, gc: TGC, 
+proc XvPutVideo*(display: PDisplay, port: TXvPortID, d: TDrawable, gc: TGC,
                  vx, vy: cint, vw, vh: cuint, dx, dy: cint, dw, dh: cuint): cint{.
     cdecl, dynlib: libXv, importc.}
-proc XvPutStill*(display: PDisplay, port: TXvPortID, d: TDrawable, gc: TGC, 
+proc XvPutStill*(display: PDisplay, port: TXvPortID, d: TDrawable, gc: TGC,
                  vx, vy: cint, vw, vh: cuint, dx, dy: cint, dw, dh: cuint): cint{.
     cdecl, dynlib: libXv, importc.}
-proc XvGetVideo*(display: PDisplay, port: TXvPortID, d: TDrawable, gc: TGC, 
+proc XvGetVideo*(display: PDisplay, port: TXvPortID, d: TDrawable, gc: TGC,
                  vx, vy: cint, vw, vh: cuint, dx, dy: cint, dw, dh: cuint): cint{.
     cdecl, dynlib: libXv, importc.}
-proc XvGetStill*(display: PDisplay, port: TXvPortID, d: TDrawable, gc: TGC, 
+proc XvGetStill*(display: PDisplay, port: TXvPortID, d: TDrawable, gc: TGC,
                  vx, vy: cint, vw, vh: cuint, dx, dy: cint, dw, dh: cuint): cint{.
     cdecl, dynlib: libXv, importc.}
 proc XvStopVideo*(display: PDisplay, port: TXvPortID, drawable: TDrawable): cint{.
     cdecl, dynlib: libXv, importc.}
-proc XvGrabPort*(display: PDisplay, port: TXvPortID, time: TTime): cint{.cdecl, 
+proc XvGrabPort*(display: PDisplay, port: TXvPortID, time: TTime): cint{.cdecl,
     dynlib: libXv, importc.}
 proc XvUngrabPort*(display: PDisplay, port: TXvPortID, time: TTime): cint{.
     cdecl, dynlib: libXv, importc.}
@@ -200,35 +200,35 @@ proc XvSelectVideoNotify*(display: PDisplay, drawable: TDrawable, onoff: TBool):
     cdecl, dynlib: libXv, importc.}
 proc XvSelectPortNotify*(display: PDisplay, port: TXvPortID, onoff: TBool): cint{.
     cdecl, dynlib: libXv, importc.}
-proc XvSetPortAttribute*(display: PDisplay, port: TXvPortID, attribute: TAtom, 
+proc XvSetPortAttribute*(display: PDisplay, port: TXvPortID, attribute: TAtom,
                          value: cint): cint{.cdecl, dynlib: libXv, importc.}
-proc XvGetPortAttribute*(display: PDisplay, port: TXvPortID, attribute: TAtom, 
-                         p_value: pcint): cint{.cdecl, dynlib: libXv, importc.}
-proc XvQueryBestSize*(display: PDisplay, port: TXvPortID, motion: TBool, 
-                      vid_w, vid_h, drw_w, drw_h: cuint, 
-                      p_actual_width, p_actual_height: pcuint): cint{.cdecl, 
+proc XvGetPortAttribute*(display: PDisplay, port: TXvPortID, attribute: TAtom,
+                         p_value: cint): cint{.cdecl, dynlib: libXv, importc.}
+proc XvQueryBestSize*(display: PDisplay, port: TXvPortID, motion: TBool,
+                      vid_w, vid_h, drw_w, drw_h: cuint,
+                      p_actual_width, p_actual_height: cuint): cint{.cdecl,
     dynlib: libXv, importc.}
-proc XvQueryPortAttributes*(display: PDisplay, port: TXvPortID, number: pcint): PXvAttribute{.
+proc XvQueryPortAttributes*(display: PDisplay, port: TXvPortID, number: cint): PXvAttribute{.
     cdecl, dynlib: libXv, importc.}
 proc XvFreeAdaptorInfo*(adaptors: PXvAdaptorInfo){.cdecl, dynlib: libXv, importc.}
-proc XvFreeEncodingInfo*(encodings: PXvEncodingInfo){.cdecl, dynlib: libXv, 
+proc XvFreeEncodingInfo*(encodings: PXvEncodingInfo){.cdecl, dynlib: libXv,
     importc.}
-proc XvListImageFormats*(display: PDisplay, port_id: TXvPortID, 
-                         count_return: pcint): PXvImageFormatValues{.cdecl, 
+proc XvListImageFormats*(display: PDisplay, port_id: TXvPortID,
+                         count_return: cint): PXvImageFormatValues{.cdecl,
     dynlib: libXv, importc.}
-proc XvCreateImage*(display: PDisplay, port: TXvPortID, id: cint, data: pointer, 
-                    width, height: cint): PXvImage{.cdecl, dynlib: libXv, 
+proc XvCreateImage*(display: PDisplay, port: TXvPortID, id: cint, data: pointer,
+                    width, height: cint): PXvImage{.cdecl, dynlib: libXv,
     importc.}
-proc XvPutImage*(display: PDisplay, id: TXvPortID, d: TDrawable, gc: TGC, 
-                 image: PXvImage, src_x, src_y: cint, src_w, src_h: cuint, 
-                 dest_x, dest_y: cint, dest_w, dest_h: cuint): cint{.cdecl, 
+proc XvPutImage*(display: PDisplay, id: TXvPortID, d: TDrawable, gc: TGC,
+                 image: PXvImage, src_x, src_y: cint, src_w, src_h: cuint,
+                 dest_x, dest_y: cint, dest_w, dest_h: cuint): cint{.cdecl,
     dynlib: libXv, importc.}
-proc XvShmPutImage*(display: PDisplay, id: TXvPortID, d: TDrawable, gc: TGC, 
-                    image: PXvImage, src_x, src_y: cint, src_w, src_h: cuint, 
-                    dest_x, dest_y: cint, dest_w, dest_h: cuint, 
+proc XvShmPutImage*(display: PDisplay, id: TXvPortID, d: TDrawable, gc: TGC,
+                    image: PXvImage, src_x, src_y: cint, src_w, src_h: cuint,
+                    dest_x, dest_y: cint, dest_w, dest_h: cuint,
                     send_event: TBool): cint{.cdecl, dynlib: libXv, importc.}
-proc XvShmCreateImage*(display: PDisplay, port: TXvPortID, id: cint, 
-                       data: pointer, width, height: cint, 
-                       shminfo: PXShmSegmentInfo): PXvImage{.cdecl, 
+proc XvShmCreateImage*(display: PDisplay, port: TXvPortID, id: cint,
+                       data: pointer, width, height: cint,
+                       shminfo: PXShmSegmentInfo): PXvImage{.cdecl,
     dynlib: libXv, importc.}
 # implementation


### PR DESCRIPTION
When i tried to use xkblib and xkb , i've encountered lower/upper case missmatches
So i went through the whole lib and fond some more.
(examples: .CDecl , Char , pcint , pcuint and some other like params case missmatches)