### PR TITLE
change TXIM and TXIC to proper C types

### DIFF
--- a/x11/xlib.nim
+++ b/x11/xlib.nim
@@ -880,10 +880,8 @@ type
     font_struct_list*: ptr PXFontStruct
     font_name_list*: PPChar
 
-  PXIM* = ptr TXIM
-  TXIM*{.final.} = object
-  PXIC* = ptr TXIC
-  TXIC*{.final.} = object
+  TXIM*{.final.} = ptr object
+  TXIC*{.final.} = ptr object
   TXIMProc* = proc (para1: TXIM, para2: TXPointer, para3: TXPointer){.cdecl.}
   TXICProc* = proc (para1: TXIC, para2: TXPointer, para3: TXPointer): TBool{.
       cdecl.}


### PR DESCRIPTION
in C they are opaque pointers and PXIM and PXIC are unused types, i put the prefix as T and not P because there is a TGC that is a pointer
```c
typedef struct _XIM *XIM;
typedef struct _XIC *XIC;
```
this may fixes #20 