### PR TITLE
Make MIT-SHM bindings link with libXext instead of libX11

### DIFF
--- a/examples/xshmex.nim
+++ b/examples/xshmex.nim
@@ -1,0 +1,98 @@
+# Example for MIT-SHM X11 extension
+# References:
+#   https://www.x.org/releases/X11R7.7/doc/xextproto/shm.html
+#   http://netpbm.sourceforge.net/doc/ppm.html
+#   https://github.com/def-/nim-syscall
+
+import x11/xlib, x11/xutil, x11/xshm, x11/x
+
+when defined(amd64):
+  type Number = enum
+    SHMGET = 29
+    SHMAT = 30
+    SHMCTL = 31
+    SHMDT = 67
+
+  proc syscall*(n: Number, a1: any): clong {.inline.} =
+    {.emit: """asm volatile(
+      "syscall" : "=a"(`result`)
+                : "a"((long)`n`), "D"((long)`a1`)
+                : "memory", "r11", "rcx", "cc");""".}
+
+  proc syscall*(n: Number, a1, a2, a3: any): clong {.inline.} =
+    {.emit: """asm volatile(
+      "syscall" : "=a"(`result`)
+                : "a"((long)`n`), "D"((long)`a1`), "S"((long)`a2`),
+                   "d"((long)`a3`)
+                : "memory", "r11", "rcx", "cc");""".}
+else:
+  {.error: "This example only supports Linux x86_64. Feel free to submit a PR to https://github.com/nim-lang/x11 to extend it.".}
+
+const
+  IPC_PRIVATE = 0
+  IPC_CREAT = 512
+  IPC_RMID = 0
+
+proc saveToPPM*(image: PXImage, filePath: string) =
+  var f = open(filePath, fmWrite)
+  defer: f.close
+  writeLine(f, "P6")
+  writeLine(f, image.width, " ", image.height)
+  writeLine(f, 255)
+  for i in 0..<(image.width * image.height):
+    f.write(image.data[i * 4 + 2])
+    f.write(image.data[i * 4 + 1])
+    f.write(image.data[i * 4 + 0])
+
+when isMainModule:
+  let display = XOpenDisplay(nil)
+  if display == nil:
+    quit("Could not open the display")
+
+  block:
+    var major, minor: cint
+    var pixmaps: TBool
+    discard XShmQueryVersion(display, addr major, addr minor, addr pixmaps)
+    echo "MIT-SHM Version ", major, ".", minor, ", Pixmaps supported: ", pixmaps
+
+  var attributes: TXWindowAttributes
+  discard XGetWindowAttributes(
+    display,
+    DefaultRootWindow(display),
+    addr attributes)
+
+  var shminfo: TXShmSegmentInfo
+  let screen = DefaultScreen(display)
+  var image = XShmCreateImage(
+    display,
+    DefaultVisual(display, screen),
+    DefaultDepthOfScreen(ScreenOfDisplay(display, screen)).cuint,
+    ZPixmap,
+    nil,
+    addr shminfo,
+    attributes.width.cuint,
+    attributes.height.cuint)
+
+  shminfo.shmid = syscall(SHMGET,
+                          IPC_PRIVATE,
+                          image.bytes_per_line * image.height,
+                          IPC_CREAT or 0o777).cint
+
+  shminfo.shmaddr = cast[cstring](syscall(SHMAT, shminfo.shmid, 0, 0))
+  image.data = shminfo.shmaddr
+  shminfo.readOnly = 0
+
+  discard XShmAttach(display, addr shminfo)
+
+  discard XShmGetImage(display, DefaultRootWindow(display), image, 0.cint, 0.cint, AllPlanes);
+  discard XSync(display, 0);
+
+  echo "Taking a screenshot using MIT-SHM extension..."
+  image.saveToPPM("./screenshot.ppm")
+  echo "DONE! Screenshot is saved in ./screenshot.ppm"
+
+  discard XShmDetach(display, addr shminfo)
+  discard XDestroyImage(image)
+  discard syscall(SHMDT, shminfo.shmaddr)
+  discard syscall(SHMCTL, shminfo.shmid, IPC_RMID, 0)
+  discard display.XCloseDisplay

--- a/x11/xshm.nim
+++ b/x11/xshm.nim
@@ -3,7 +3,7 @@ import
   x, xlib
 
 const
- libXext* = "libXext.so"
+ libXext* = "libXext.so(.6|)"
 
 #
 #  Automatically converted by H2Pas 0.99.15 from xshm.h

--- a/x11/xshm.nim
+++ b/x11/xshm.nim
@@ -2,8 +2,8 @@
 import
   x, xlib
 
-#const
-#  libX11* = "libX11.so"
+const
+ libXext* = "libXext.so"
 
 #
 #  Automatically converted by H2Pas 0.99.15 from xshm.h
@@ -51,27 +51,27 @@ type
     readOnly*: TBool
 
 
-proc XShmQueryExtension*(para1: PDisplay): TBool{.cdecl, dynlib: libX11, importc.}
-proc XShmGetEventBase*(para1: PDisplay): cint{.cdecl, dynlib: libX11, importc.}
+proc XShmQueryExtension*(para1: PDisplay): TBool{.cdecl, dynlib: libXext, importc.}
+proc XShmGetEventBase*(para1: PDisplay): cint{.cdecl, dynlib: libXext, importc.}
 proc XShmQueryVersion*(para1: PDisplay, para2: Pcint, para3: Pcint, para4: PBool): TBool{.
-    cdecl, dynlib: libX11, importc.}
-proc XShmPixmapFormat*(para1: PDisplay): cint{.cdecl, dynlib: libX11, importc.}
+    cdecl, dynlib: libXext, importc.}
+proc XShmPixmapFormat*(para1: PDisplay): cint{.cdecl, dynlib: libXext, importc.}
 proc XShmAttach*(para1: PDisplay, para2: PXShmSegmentInfo): TStatus{.cdecl,
-    dynlib: libX11, importc.}
+    dynlib: libXext, importc.}
 proc XShmDetach*(para1: PDisplay, para2: PXShmSegmentInfo): TStatus{.cdecl,
-    dynlib: libX11, importc.}
+    dynlib: libXext, importc.}
 proc XShmPutImage*(para1: PDisplay, para2: TDrawable, para3: TGC,
                    para4: PXImage, para5: cint, para6: cint, para7: cint,
                    para8: cint, para9: cuint, para10: cuint, para11: TBool): TStatus{.
-    cdecl, dynlib: libX11, importc.}
+    cdecl, dynlib: libXext, importc.}
 proc XShmGetImage*(para1: PDisplay, para2: TDrawable, para3: PXImage,
                    para4: cint, para5: cint, para6: culong): TStatus{.cdecl,
-    dynlib: libX11, importc.}
+    dynlib: libXext, importc.}
 proc XShmCreateImage*(para1: PDisplay, para2: PVisual, para3: cuint,
                       para4: cint, para5: cstring, para6: PXShmSegmentInfo,
                       para7: cuint, para8: cuint): PXImage{.cdecl,
-    dynlib: libX11, importc.}
+    dynlib: libXext, importc.}
 proc XShmCreatePixmap*(para1: PDisplay, para2: TDrawable, para3: cstring,
                        para4: PXShmSegmentInfo, para5: cuint, para6: cuint,
-                       para7: cuint): TPixmap{.cdecl, dynlib: libX11, importc.}
+                       para7: cuint): TPixmap{.cdecl, dynlib: libXext, importc.}
 # implementation


### PR DESCRIPTION
XShm is usually available in libXext rather than libX11 on the majority of Linux distros: https://github.com/freedesktop/libXext/blob/master/include/X11/extensions/XShm.h

Fixed that plus added a small example on how to use MIT-SHM. Maybe it will be useful for somebody in the future.

Please let me know your thoughts.