### PR TITLE
Created a wrapper for Xft.

### DIFF
--- a/examples/xftex.nim
+++ b/examples/xftex.nim
@@ -1,0 +1,109 @@
+import 
+  x11/xlib,
+  x11/xutil,
+  x11/x,
+  x11/xft,
+  x11/xrender
+
+const
+  WINDOW_WIDTH = 400
+  WINDOW_HEIGHT = 300
+
+var
+  width, height: cuint
+  display: PDisplay
+  screen: cint
+  depth: int
+  win: Window
+  sizeHints: XSizeHints
+  wmDeleteMessage: Atom
+  running: bool
+  xev: XEvent
+  displayString = "Hello, Nimrods."
+  fontName = "monospace:size=10"
+  font: PXftFont
+  xftDraw: PXftDraw
+  xftColor: XftColor
+
+proc create_window = 
+  width = WINDOW_WIDTH
+  height = WINDOW_HEIGHT
+
+  display = XOpenDisplay(nil)
+  if display == nil:
+    quit "Failed to open display"
+
+  screen = XDefaultScreen(display)
+
+  font = XftFontOpenXlfd(display, screen, fontName)
+  if font == nil:
+    font = XftFontOpenName(display, screen, fontName)
+    if font == nil:
+      quit "Failed to load a valid font"
+
+  depth = XDefaultDepth(display, screen)
+  var rootwin = XRootWindow(display, screen)
+  win = XCreateSimpleWindow(display, rootwin, 100, 10,
+                            width, height, 5,
+                            XBlackPixel(display, screen),
+                            XWhitePixel(display, screen))
+  sizeHints.flags = PSize or PMinSize or PMaxSize
+  sizeHints.min_width =  width.cint
+  sizeHints.max_width =  width.cint
+  sizeHints.min_height = height.cint
+  sizeHints.max_height = height.cint
+  discard XSetStandardProperties(display, win, "Simple Window", "window",
+                         0, nil, 0, addr(sizeHints))
+  discard XSelectInput(display, win, ButtonPressMask or KeyPressMask or 
+                                     PointerMotionMask or ExposureMask)
+  discard XMapWindow(display, win)
+
+  wmDeleteMessage = XInternAtom(display, "WM_DELETE_WINDOW", false.XBool)
+  discard XSetWMProtocols(display, win, wmDeleteMessage.addr, 1)
+
+  xftDraw = XftDrawCreate(display, win, DefaultVisual(display, 0), DefaultColormap(display, 0))
+  var xrenderColor: XRenderColor
+  xrenderColor.red = 65535
+  xrenderColor.green = 0
+  xrenderColor.blue = 0
+  xrenderColor.alpha = 65535
+  discard XftColorAllocValue(
+    display,
+    DefaultVisual(display, 0),
+    DefaultColormap(display, 0),
+    xrenderColor.addr,
+    xftColor.addr
+  )
+
+  running = true
+
+proc close_window =
+  discard XDestroyWindow(display, win)
+  discard XCloseDisplay(display)
+
+proc draw_screen =
+  # TODO: This is rendering strange characters, but the first letter is always correct.
+  XftDrawStringUtf8(xftDraw, xftColor.addr, font, 20, 70, cast[PFcChar8](displayString.addr), displayString.len.cint)
+
+proc handle_event =
+  discard XNextEvent(display, xev.addr)
+  case xev.theType
+  of Expose:
+    draw_screen()
+  of ClientMessage:
+    if cast[Atom](xev.xclient.data.l[0]) == wmDeleteMessage:
+      running = false
+  of KeyPress:
+    var key = XLookupKeysym(cast[PXKeyEvent](xev.addr), 0)
+    if key != 0:
+      echo "Keyboard event"
+  of ButtonPressMask, PointerMotionMask:
+    echo "Mouse event"
+  else:
+    discard
+
+create_window()
+while running:
+  handle_event()
+close_window()
+

--- a/examples/xftex.nim
+++ b/examples/xftex.nim
@@ -35,11 +35,9 @@ proc create_window =
 
   screen = XDefaultScreen(display)
 
-  font = XftFontOpenXlfd(display, screen, fontName)
+  font = XftFontOpenName(display, screen, fontName)
   if font == nil:
-    font = XftFontOpenName(display, screen, fontName)
-    if font == nil:
-      quit "Failed to load a valid font"
+    quit "Failed to load a valid font"
 
   depth = XDefaultDepth(display, screen)
   var rootwin = XRootWindow(display, screen)
@@ -82,8 +80,7 @@ proc close_window =
   discard XCloseDisplay(display)
 
 proc draw_screen =
-  # TODO: This is rendering strange characters, but the first letter is always correct.
-  XftDrawStringUtf8(xftDraw, xftColor.addr, font, 20, 70, cast[PFcChar8](displayString.addr), displayString.len.cint)
+  XftDrawStringUtf8(xftDraw, xftColor.addr, font, 20, 70, cast[PFcChar8](displayString[0].addr), displayString.len.cint)
 
 proc handle_event =
   discard XNextEvent(display, xev.addr)

--- a/x11.nimble
+++ b/x11.nimble
@@ -8,3 +8,4 @@ requires "nim > 0.9.2"
 task test, "test":
   exec "nim c examples/x11ex.nim"
   exec "nim c examples/xshmex.nim"
+  exec "nim c examples/xftex.nim"

--- a/x11/xft.nim
+++ b/x11/xft.nim
@@ -52,10 +52,10 @@ type
   XftFontInfo* = object 
   PXftFontInfo* = ptr XftFontInfo
   XftFont* = object
-    ascent*: int
-    descent*: int
-    height*: int
-    max_advance_width*: int
+    ascent*: cint
+    descent*: cint
+    height*: cint
+    max_advance_width*: cint
     charset*: PFcCharSet
     pattern*: PFcPattern    
   PXftFont* = ptr XftFont
@@ -130,7 +130,7 @@ proc XftDefaultSet*(
 
 proc XftDefaultSubstitute*(
   display: PDisplay,
-  screen: int,
+  screen: cint,
   pattern: PFcPattern
 ) {.cdecl, dynlib: xftLib, importc.}
 

--- a/x11/xft.nim
+++ b/x11/xft.nim
@@ -8,9 +8,15 @@ import
 const
   xftLib = "libXft.so"
 
+# Defined in the FreeType library
 type
-  # TODO: From /usr/include/fontconfig/fontconfig.h
-  # Should these Fc* declarations be in a fontconfig.nim?
+  FT_UInt* = cuint
+  PFT_UInt* = ptr FT_UInt
+  FT_Face* = object
+  PFT_Face* = ptr FT_Face
+
+# Defined in the fontconfig library
+type
   FcEndian* = enum
     FcEndianBig, FcEndianLittle
 
@@ -42,6 +48,7 @@ type
   FcChar32* = cuint
   PFcChar32* = ptr FcChar32
 
+type
   XftFontInfo* = object 
   PXftFontInfo* = ptr XftFontInfo
   XftFont* = object
@@ -86,13 +93,6 @@ type
     x: cshort
     y: cshort
   PXftGlyphFontSpec = ptr XftGlyphFontSpec
-
-  # TODO: Defined in the FreeType library
-  # Need a FreeType wrapper?
-  FT_UInt* = cuint
-  PFT_UInt* = ptr FT_UInt
-  FT_Face* = object
-  PFT_Face* = ptr FT_Face
 
 # xftcolor.c
 proc XftColorAllocName*(

--- a/x11/xft.nim
+++ b/x11/xft.nim
@@ -34,9 +34,9 @@ type
   PFcPattern* = ptr FcPattern
 
   FcFontSet* = object
-    nfont: cint
-    sfont: cint
-    fonts: ptr PFcPattern
+    nfont*: cint
+    sfont*: cint
+    fonts*: ptr PFcPattern
   PFcFontSet* = ptr FcFontSet
 
   FcChar8* = cuchar
@@ -52,12 +52,12 @@ type
   XftFontInfo* = object 
   PXftFontInfo* = ptr XftFontInfo
   XftFont* = object
-    ascent: int
-    descent: int
-    height: int
-    max_advance_width: int
-    charset: PFcCharSet
-    pattern: PFcPattern    
+    ascent*: int
+    descent*: int
+    height*: int
+    max_advance_width*: int
+    charset*: PFcCharSet
+    pattern*: PFcPattern    
   PXftFont* = ptr XftFont
 
   XftDraw* = object
@@ -65,33 +65,33 @@ type
 
   XftColor* = object
     pixel*: culong
-    color: XRenderColor
+    color*: XRenderColor
   PXftColor* = ptr XftColor
 
   XftCharSpec* = object
-    ucs4: FcChar32
-    x: cshort
-    y: cshort
+    ucs4*: FcChar32
+    x*: cshort
+    y*: cshort
   PXftCharSpec* = ptr XftCharSpec
 
   XftCharFontSpec* = object
-    font: PXftFont
-    ucs4: FcChar32
-    x: cshort
-    y: cshort
+    font*: PXftFont
+    ucs4*: FcChar32
+    x*: cshort
+    y*: cshort
   PXftCharFontSpec* = ptr XftCharFontSpec
 
   XftGlyphSpec* = object
-    glyph: FT_UInt
-    x: cshort
-    y: cshort
+    glyph*: FT_UInt
+    x*: cshort
+    y*: cshort
   PXftGlyphSpec* = ptr XftGlyphSpec
 
   XftGlyphFontSpec* = object
-    font: PXftFont
-    glyph: FT_UInt
-    x: cshort
-    y: cshort
+    font*: PXftFont
+    glyph*: FT_UInt
+    x*: cshort
+    y*: cshort
   PXftGlyphFontSpec = ptr XftGlyphFontSpec
 
 # xftcolor.c
@@ -99,7 +99,7 @@ proc XftColorAllocName*(
   display: PDisplay,
   visual: PVisual,
   cmap: Colormap,
-  name: ptr cchar,
+  name: cstring,
   result: PXftColor
 ): XBool {.cdecl, dynlib: xftLib, importc.}
 
@@ -371,13 +371,13 @@ proc XftFontOpen*(
 proc XftFontOpenName*(
   display: PDisplay,
   screen: cint,
-  name: ptr cchar
+  name: cstring
 ): PXftFont {.cdecl, dynlib: xftLib, importc.}
 
 proc XftFontOpenXlfd*(
   display: PDisplay,
   screen: cint,
-  xlfd: ptr cchar
+  xlfd: cstring
 ): PXftFont {.cdecl, dynlib: xftLib, importc.}
 
 # xftfreetype.c
@@ -407,7 +407,6 @@ proc XftFontInfoEqual*(
   a: PXftFontInfo,
   b: PXftFontInfo
 ): FcBool {.cdecl, dynlib: xftLib, importc.}
-
 
 proc XftFontOpenInfo*(
   display: PDisplay,
@@ -473,7 +472,7 @@ proc XftCharIndex*(
 
 # xftinit.c
 proc XftInit*(
-  config: ptr cchar
+  config: cstring
 ): FcBool {.cdecl, dynlib: xftLib, importc.}
 
 proc XftGetVersion*(): cint {.cdecl, dynlib: xftLib, importc.}
@@ -487,7 +486,7 @@ proc XftListFonts*(
 
 # xftname.c
 proc XftNameParse*(
-  name: ptr cchar
+  name: cstring
 ): PFcPattern {.cdecl, dynlib: xftLib, importc.}
 
 # xftrender.c
@@ -674,7 +673,7 @@ proc XftTextRenderUtf16*(
 
 # xftxlfd.c
 proc XftXlfdParse8*(
-  xlfd_orig: ptr cchar,
+  xlfd_orig: cstring,
   ignore_scalable: XBool,
   complete: XBool
 ): PFcPattern {.cdecl, dynlib: xftLib, importc.}

--- a/x11/xft.nim
+++ b/x11/xft.nim
@@ -1,0 +1,681 @@
+# Converted from X11/Xft/Xft.h
+import
+  x,
+  xlib,
+  xrender,
+  xutil
+
+const
+  xftLib = "libXft.so"
+
+type
+  # TODO: From /usr/include/fontconfig/fontconfig.h
+  # Should these Fc* declarations be in a fontconfig.nim?
+  FcEndian* = enum
+    FcEndianBig, FcEndianLittle
+
+  FcResult* = enum
+    FcResultMatch, FcResultNoMatch, FcResultTypeMismatch,
+    FcResultNoId, FcResultOutOfMemory
+  PFcResult* = ptr FcResult
+
+  FcBool* = cint
+
+  FcCharSet* = object
+  PFcCharSet* = ptr FcCharSet
+
+  FcPattern* = object
+  PFcPattern* = ptr FcPattern
+
+  FcFontSet* = object
+    nfont: cint
+    sfont: cint
+    fonts: ptr PFcPattern
+  PFcFontSet* = ptr FcFontSet
+
+  FcChar8* = cuchar
+  PFcChar8* = ptr FcChar8
+
+  FcChar16* = cushort
+  PFcChar16* = ptr FcChar16
+
+  FcChar32* = cuint
+  PFcChar32* = ptr FcChar32
+
+  XftFontInfo* = object 
+  PXftFontInfo* = ptr XftFontInfo
+  XftFont* = object
+    ascent: int
+    descent: int
+    height: int
+    max_advance_width: int
+    charset: PFcCharSet
+    pattern: PFcPattern    
+  PXftFont* = ptr XftFont
+
+  XftDraw* = object
+  PXftDraw* = ptr XftDraw
+
+  XftColor* = object
+    pixel*: culong
+    color: XRenderColor
+  PXftColor* = ptr XftColor
+
+  XftCharSpec* = object
+    ucs4: FcChar32
+    x: cshort
+    y: cshort
+  PXftCharSpec* = ptr XftCharSpec
+
+  XftCharFontSpec* = object
+    font: PXftFont
+    ucs4: FcChar32
+    x: cshort
+    y: cshort
+  PXftCharFontSpec* = ptr XftCharFontSpec
+
+  XftGlyphSpec* = object
+    glyph: FT_UInt
+    x: cshort
+    y: cshort
+  PXftGlyphSpec* = ptr XftGlyphSpec
+
+  XftGlyphFontSpec* = object
+    font: PXftFont
+    glyph: FT_UInt
+    x: cshort
+    y: cshort
+  PXftGlyphFontSpec = ptr XftGlyphFontSpec
+
+  # TODO: Defined in the FreeType library
+  # Need a FreeType wrapper?
+  FT_UInt* = cuint
+  PFT_UInt* = ptr FT_UInt
+  FT_Face* = object
+  PFT_Face* = ptr FT_Face
+
+# xftcolor.c
+proc XftColorAllocName*(
+  display: PDisplay,
+  visual: PVisual,
+  cmap: Colormap,
+  name: ptr cchar,
+  result: PXftColor
+): XBool {.cdecl, dynlib: xftLib, importc.}
+
+proc XftColorAllocValue*(
+  display: PDisplay,
+  visual: PVisual,
+  cmap: Colormap,
+  color: PXRenderColor,
+  result: PXftColor
+): XBool {.cdecl, dynlib: xftLib, importc.}
+
+proc XftColorFree*(
+  display: PDisplay,
+  visual: PVisual,
+  cmap: Colormap,
+  color: PXftColor
+) {.cdecl, dynlib: xftLib, importc.} 
+
+# xftdpy.c
+proc XftDefaultHasRender*(
+  display: PDisplay
+): XBool {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDefaultSet*(
+  display: PDisplay,
+  defaults: PFcPattern
+): XBool {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDefaultSubstitute*(
+  display: PDisplay,
+  screen: int,
+  pattern: PFcPattern
+) {.cdecl, dynlib: xftLib, importc.}
+
+# xftdraw.c
+proc XftDrawCreate*(
+  display: PDisplay,
+  drawable: Drawable,
+  visual: PVisual,
+  colormap: Colormap 
+): PXftDraw {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawCreateBitmap*(
+  display: PDisplay,
+  bitmap: Pixmap
+): PXftDraw {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawCreateAlpha*(
+  display: PDisplay,
+  pixmap: Pixmap,
+  depth: cint
+): PXftDraw {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawChange*(
+  draw: PXftDraw,
+  drawable: Drawable
+) {.cdecl, dynlib: xftLib, importc.} 
+
+proc XftDrawDisplay*(
+  draw: PXftDraw
+): PDisplay {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawDrawable*(
+  draw: PXftDraw
+): Drawable {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawColormap*(
+  draw: PXftDraw
+): Colormap {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawVisual*(
+  draw: PXftDraw
+): PVisual {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawDestroy*(
+  draw: PXftDraw
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawPicture*(
+  draw: PXftDraw
+): Picture {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawSrcPicture*(
+  draw: PXftDraw,
+  color: PXftColor
+): Picture {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawGlyphs*(
+  draw: PXftDraw,
+  color: PXftColor,
+  pub: PXftFont,
+  x: cint,
+  y: cint,
+  glyphs: PFt_UInt,
+  nglyphs: cint
+) {.cdecl, dynlib: xftLib, importc.} 
+
+proc XftDrawString8*(
+  draw: PXftDraw,
+  color: PXftColor,
+  pub: PXftFont,
+  x: cint,
+  y: cint,
+  str: PFcChar8,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawString16*(
+  draw: PXftDraw,
+  color: PXftColor,
+  pub: PXftFont,
+  x: cint,
+  y: cint,
+  str: PFcChar16,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawString32*(
+  draw: PXftDraw,
+  color: PXftColor,
+  pub: PXftFont,
+  x: cint,
+  y: cint,
+  str: PFcChar32,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawStringUtf8*(
+  draw: PXftDraw,
+  color: PXftColor,
+  pub: PXftFont,
+  x: cint,
+  y: cint,
+  str: PFcChar8,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawStringUtf16*(
+  draw: PXftDraw,
+  color: PXftColor,
+  pub: PXftFont,
+  x: cint,
+  y: cint,
+  str: PFcChar8,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawCharSpec*(
+  draw: PXftDraw,
+  color: PXftColor,
+  pub: PXftFont,
+  chars: PXftCharSpec,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawCharFontSpec*(
+  draw: PXftDraw,
+  color: PXftColor,
+  chars: PXftCharFontSpec,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawGlyphSpec*(
+  draw: PXftDraw,
+  color: PXftColor,
+  pub: PXftFont,
+  glyphs: PXftGlyphSpec,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawGlyphFontSpec*(
+  draw: PXftDraw,
+  color: PXftColor,
+  glyphs: PXftGlyphFontSpec,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawRect*(
+  draw: PXftDraw,
+  color: PXftColor,
+  x: cint,
+  y: cint,
+  width: cuint,
+  height: cuint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawSetClip*(
+  draw: PXftDraw,
+  r: Region
+): XBool {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawSetClipRectangles*(
+  draw: PXftDraw,
+  xOrigin: cint,
+  yOrigin: cint,
+  rects: PXRectangle,
+  n: cint
+): XBool {.cdecl, dynlib: xftLib, importc.}
+
+proc XftDrawSetSubwindowMode*(
+  draw: PXftDraw,
+  mode: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+# xftextent.c
+proc XftGlyphExtents*(
+  display: PDisplay,
+  pub: PXftFont,
+  glyphs: PFT_UInt,
+  nglyphs: cint,
+  extends: PXGlyphInfo
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftTextExtents8*(
+  display: PDisplay,
+  pub: PXftFont,
+  str: PFcChar8,
+  len: cint,
+  extents: PXGlyphInfo
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftTextExtents16*(
+  display: PDisplay,
+  pub: PXftFont,
+  str: PFcChar16,
+  len: cint,
+  extents: PXGlyphInfo
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftTextExtents32*(
+  display: PDisplay,
+  pub: PXftFont,
+  str: PFcChar32,
+  len: cint,
+  extents: PXGlyphInfo
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftTextExtentsUtf8*(
+  display: PDisplay,
+  pub: PXftFont,
+  str: PFcChar8,
+  len: cint,
+  extents: PXGlyphInfo
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftTextExtentsUtf16*(
+  display: PDisplay,
+  pub: PXftFont,
+  str: PFcChar8,
+  endian: FcEndian,
+  len: cint,
+  extents: PXGlyphInfo
+) {.cdecl, dynlib: xftLib, importc.}
+
+# xftfont.c
+proc XftFontMatch*(
+  display: PDisplay,
+  screen: cint,
+  pattern: PFcPattern,
+  result: PFcResult
+): PFcPattern {.cdecl, dynlib: xftLib, importc.}
+
+# Expects display to be nil as an argument
+proc XftFontOpen*(
+  display: PDisplay,
+  screen: cint
+): PXftFont {.cdecl, dynlib: xftLib, importc, varargs.}
+
+proc XftFontOpenName*(
+  display: PDisplay,
+  screen: cint,
+  name: ptr cchar
+): PXftFont {.cdecl, dynlib: xftLib, importc.}
+
+proc XftFontOpenXlfd*(
+  display: PDisplay,
+  screen: cint,
+  xlfd: ptr cchar
+): PXftFont {.cdecl, dynlib: xftLib, importc.}
+
+# xftfreetype.c
+proc XftLockFace*(
+  pub: PXftFont
+): FT_Face {.cdecl, dynlib: xftLib, importc.}
+
+proc XftUnlockFace*(
+  pub: PXftFont
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftFontInfoCreate*(
+  display: PDisplay,
+  pattern: PFcPattern
+): PXftFontInfo {.cdecl, dynlib: xftLib, importc.}
+
+proc XftFontInfoDestroy*(
+  display: PDisplay,
+  fi: PXftFontInfo
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftFontInfoHash*(
+  fi: PXftFontInfo
+): PFcChar32 {.cdecl, dynlib: xftLib, importc.}
+
+proc XftFontInfoEqual*(
+  a: PXftFontInfo,
+  b: PXftFontInfo
+): FcBool {.cdecl, dynlib: xftLib, importc.}
+
+
+proc XftFontOpenInfo*(
+  display: PDisplay,
+  pattern: PFcPattern,
+  fi: PXftFontInfo
+): PXftFont {.cdecl, dynlib: xftLib, importc.}
+
+proc XftFontOpenPattern*(
+  display: PDisplay,
+  pattern: PFcPattern
+): PXftFont {.cdecl, dynlib: xftLib, importc.}
+
+proc XftFontCopy*(
+  display: PDisplay,
+  pub: PXftFont
+): PXftFont {.cdecl, dynlib: xftLib, importc.}
+
+proc XftFontClose*(
+  display: PDisplay,
+  pub: PXftFont
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftInitFtLibrary*(): FcBool {.cdecl, dynlib: xftLib, importc.}
+
+# xftglyphs.c
+proc XftFontLoadGlyphs*(
+  display: PDisplay,
+  pub: PXftFont,
+  need_bitmaps: FcBool,
+  glyphs: PFT_UInt,
+  nglyph: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftFontUnloadGlyphs*(
+  display: PDisplay,
+  pub: PXftFont,
+  glyphs: PFT_UInt,
+  nglyph: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+const XFT_NMISSING* = 256
+
+proc XftFontCheckGlyph*(
+  display: PDisplay,
+  pub: PXftFont,
+  need_bitmaps: FcBool,
+  glyph: FT_UInt,
+  missing: PFT_UInt,
+  nmissing: cint
+): FcBool {.cdecl, dynlib: xftLib, importc.}
+
+proc XftCharExists*(
+  display: PDisplay,
+  pub: PXftFont,
+  ucs4: FcChar32
+): FcBool {.cdecl, dynlib: xftLib, importc.}
+
+proc XftCharIndex*(
+  display: PDisplay,
+  pub: PXftFont,
+  ucs4: FcChar32
+): FT_UInt {.cdecl, dynlib: xftLib, importc.}
+
+# xftinit.c
+proc XftInit*(
+  config: ptr cchar
+): FcBool {.cdecl, dynlib: xftLib, importc.}
+
+proc XftGetVersion*(): cint {.cdecl, dynlib: xftLib, importc.}
+
+# xftlist.c
+# Expects display to be nil as an argument
+proc XftListFonts*(
+  display: PDisplay,
+  screen: cint
+): PFcFontSet {.cdecl, dynlib: xftLib, importc, varargs.}
+
+# xftname.c
+proc XftNameParse*(
+  name: ptr cchar
+): PFcPattern {.cdecl, dynlib: xftLib, importc.}
+
+# xftrender.c
+proc XftGlyphRender*(display: PDisplay,
+  op: cint,
+  src: Picture,
+  pub: PXftFont,
+  dst: Picture,
+  srcx: cint,
+  srcy: cint,
+  x: cint,
+  y: cint,
+  glyphs: PFT_UInt,
+  nglyphs: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftGlyphSpecRender*(display: PDisplay,
+  op: cint,
+  src: Picture,
+  pub: PXftFont,
+  dst: Picture,
+  srcx: cint,
+  srcy: cint,
+  glyphs: PXftGlyphSpec,
+  nglyphs: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftCharSpecRender*(display: PDisplay,
+  op: cint,
+  src: Picture,
+  pub: PXftFont,
+  dst: Picture,
+  srcx: cint,
+  srcy: cint,
+  chars: PXftCharSpec,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftGlyphFontSpecRender*(display: PDisplay,
+  op: cint,
+  src: Picture,
+  dst: Picture,
+  srcx: cint,
+  srcy: cint,
+  glyphs: PXftGlyphFontSpec,
+  nglyphs: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftCharFontSpecRender*(display: PDisplay,
+  op: cint,
+  src: Picture,
+  dst: Picture,
+  srcx: cint,
+  srcy: cint,
+  chars: PXftCharFontSpec,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftTextRender8*(display: PDisplay,
+  op: cint,
+  src: Picture,
+  pub: PXftFont,
+  dst: Picture,
+  srcx: cint,
+  srcy: cint,
+  x: cint,
+  y: cint,
+  str: PFcChar8,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftTextRender16*(
+  display: PDisplay,
+  op: cint,
+  src: Picture,
+  pub: PXftFont,
+  dst: Picture,
+  srcx: cint,
+  srcy: cint,
+  x: cint,
+  y: cint,
+  str: PFcChar16,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftTextRender16BE*(
+  display: PDisplay,
+  op: cint,
+  src: Picture,
+  pub: PXftFont,
+  dst: Picture,
+  srcx: cint,
+  srcy: cint,
+  x: cint,
+  y: cint,
+  str: PFcChar8,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftTextRender16LE*(
+  display: PDisplay,
+  op: cint,
+  src: Picture,
+  pub: PXftFont,
+  dst: Picture,
+  srcx: cint,
+  srcy: cint,
+  x: cint,
+  y: cint,
+  str: PFcChar8,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftTextRender32*(
+  display: PDisplay,
+  op: cint,
+  src: Picture,
+  pub: PXftFont,
+  dst: Picture,
+  srcx: cint,
+  srcy: cint,
+  x: cint,
+  y: cint,
+  str: PFcChar32,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftTextRender32BE*(
+  display: PDisplay,
+  op: cint,
+  src: Picture,
+  pub: PXftFont,
+  dst: Picture,
+  srcx: cint,
+  srcy: cint,
+  x: cint,
+  y: cint,
+  str: PFcChar8,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftTextRender32LE*(
+  display: PDisplay,
+  op: cint,
+  src: Picture,
+  pub: PXftFont,
+  dst: Picture,
+  srcx: cint,
+  srcy: cint,
+  x: cint,
+  y: cint,
+  str: PFcChar8,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftTextRenderUtf8*(
+  display: PDisplay,
+  op: cint,
+  src: Picture,
+  pub: PXftFont,
+  dst: Picture,
+  srcx: cint,
+  srcy: cint,
+  x: cint,
+  y: cint,
+  str: PFcChar8,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+proc XftTextRenderUtf16*(
+  display: PDisplay,
+  op: cint,
+  src: Picture,
+  pub: PXftFont,
+  dst: Picture,
+  srcx: cint,
+  srcy: cint,
+  x: cint,
+  y: cint,
+  str: PFcChar8,
+  endian: FcEndian,
+  len: cint
+) {.cdecl, dynlib: xftLib, importc.}
+
+# xftxlfd.c
+proc XftXlfdParse8*(
+  xlfd_orig: ptr cchar,
+  ignore_scalable: XBool,
+  complete: XBool
+): PFcPattern {.cdecl, dynlib: xftLib, importc.}
+

--- a/x11/xrender.nim
+++ b/x11/xrender.nim
@@ -211,6 +211,13 @@ type
     xOff*: int16
     yOff*: int16
 
+  PXRenderColor* = ptr XRenderColor
+  XRenderColor* = object
+    red: cushort
+    green: cushort
+    blue: cushort
+    alpha: cushort
+
 {.deprecated: [TXRenderVisual: XRenderVisual].}
 {.deprecated: [TXRenderDepth: XRenderDepth].}
 {.deprecated: [TXRenderScreen: XRenderScreen].}

--- a/x11/xrender.nim
+++ b/x11/xrender.nim
@@ -213,10 +213,10 @@ type
 
   PXRenderColor* = ptr XRenderColor
   XRenderColor* = object
-    red: cushort
-    green: cushort
-    blue: cushort
-    alpha: cushort
+    red*: cushort
+    green*: cushort
+    blue*: cushort
+    alpha*: cushort
 
 {.deprecated: [TXRenderVisual: XRenderVisual].}
 {.deprecated: [TXRenderDepth: XRenderDepth].}


### PR DESCRIPTION
Created a wrapper and test for Xft.

Some types in xft.nim belong to `fontconfig` and `FreeType` (they are commented as so).

They were needed for Xft, but those entire libs don't need to be wrapped. If we want to separate them into different files or something, let me know.