### PR TITLE
add xinput2 and xge wrappers

### DIFF
--- a/examples/xi2ex.nim
+++ b/examples/xi2ex.nim
@@ -1,0 +1,210 @@
+import
+  x11/xlib,
+  x11/xutil,
+  x11/x,
+  x11/xi2,
+  x11/xinput2
+
+const
+  windowWidth = 1000
+  windowHeight = 600
+  borderWidth = 5
+  eventMask = ButtonPressMask or KeyPressMask or ExposureMask
+
+type
+  GUIDeviceFlags = enum
+    devStylus, devEraser
+  GUIDevice = object
+    id: int32
+    # Attributes of Device
+    flags: set[GUIDeviceFlags]
+    # Pressure Information
+    pmin, pmax, plast: float
+    # Number Information
+    btn_num, pnum: int32
+
+var
+  display: PDisplay
+  window: Window
+  deleteMessage: Atom
+  graphicsContext: GC
+  # XInput2 Stuff
+  xi_opcode: int32
+  # Device List
+  devices: seq[GUIDevice]
+
+proc init() =
+  display = XOpenDisplay(nil)
+  if display == nil:
+    quit "Failed to open display"
+
+  var aux: int32
+  # Query XInput2 Extension
+  aux = XQueryExtension(display, "XInputExtension", 
+    addr xi_opcode, addr aux, addr aux)
+  if aux == 0:
+    quit "Failed to load XInput Extension"
+
+  # Check if is XInput2
+  var 
+    major = int32(2)
+    minor = int32(3)
+  aux = XIQueryVersion(display, 
+    addr major, addr minor)
+  if aux != Success:
+    quit "XInput Extension is not XInput2"
+
+  # Create Window
+  let
+    screen = XDefaultScreen(display)
+    rootWindow = XRootWindow(display, screen)
+    foregroundColor = XBlackPixel(display, screen)
+    backgroundColor = XWhitePixel(display, screen)
+
+  window = XCreateSimpleWindow(display, rootWindow, -1, -1, windowWidth,
+      windowHeight, borderWidth, foregroundColor, backgroundColor)
+
+  discard XSetStandardProperties(display, window, "XI2 Example", "window", 0,
+      nil, 0, nil)
+  discard XSelectInput(display, window, eventMask)
+  discard XMapWindow(display, window)
+
+  block: # Select XI2 Devices
+    var 
+      device_n: int32
+      device: PXIDeviceInfo
+      device_class: PXIAnyClassInfo
+    let 
+      device_list = cast[ptr UncheckedArray[XIDeviceInfo]](
+        XIQueryDevice(display, XIAllDevices, addr device_n))
+      # Look for Pressure Axis, Tilt will be added sometime
+      p_label = XInternAtom(display, "Abs Pressure", false.XBool)
+    # Iterate Each Device
+    for i in 0..<device_n:
+      device = addr device_list[i]
+      if device.use != XISlavePointer:
+        continue # Skip Not Slave Pointers
+      echo device.name
+      # New Device Item
+      var item: GUIDevice
+      # Store Device ID
+      item.id = device.deviceid
+      # Shortcur for Device Classes
+      let device_classes = cast[ptr 
+        UncheckedArray[PXIAnyClassInfo]](device.classes)
+      # Get Buttons and Valuators
+      for j in 0..<device.num_classes:
+        device_class = device_classes[j]
+        # Store Number of Buttons
+        if device_class.`type` == XIButtonClass:
+          item.btn_num = cast[PXIButtonClassInfo](device_class).num_buttons
+        # Store Pressure Ranges
+        if device_class.`type` == XIValuatorClass:
+          let valuator = cast[PXIValuatorClassInfo](device_class)
+          if valuator.label == p_label:
+            item.pnum = valuator.number
+            item.pmin = valuator.min
+            item.pmax = valuator.max
+      # Store New Device Item
+      devices.add(item)
+    # Free Device Info
+    XIFreeDeviceInfo(
+      cast[PXIDeviceInfo](device_list))
+
+  block: # Enable XI2 Events
+    var 
+      em: XIEventMask
+      mask: uint8
+      # Nim Shortcut
+      p_mask = addr mask
+    em.deviceid = 2
+    em.mask_len = 1
+    em.mask = cast[ptr cuchar](p_mask)
+    # Set XInput2 Masks
+    XISetMask(p_mask, XI_ButtonPress)
+    XISetMask(p_mask, XI_ButtonRelease)
+    XISetMask(p_mask, XI_Motion)
+    # Bind To Current Display and Window
+    discard XISelectEvents(display, window, addr em, 1)
+
+  # Additional X11 Stuff
+  deleteMessage = XInternAtom(display, "WM_DELETE_WINDOW", false.XBool)
+  discard XSetWMProtocols(display, window, deleteMessage.addr, 1)
+
+  graphicsContext = XDefaultGC(display, screen)
+
+
+proc drawWindow() =
+  const text = "XInput2 Graphics Tablet Example, see console for events information"
+  discard XDrawString(display, window, graphicsContext, 10, 50, text, text.len)
+
+proc processGeneric(ev: PXEvent) =
+  let 
+    dev = cast[PXIDeviceEvent](ev.xcookie.data)
+    kind = dev.evtype
+  # Print what kind is
+  if kind == XI_Motion:
+    echo "XI2 Device Motion:"
+  elif kind == XI_ButtonPress:
+    echo "XI2 Button Pressed:"
+  elif kind == XI_ButtonRelease:
+    echo "XI2 Button Released:"
+  else: return
+  # Print Pen Coordinates
+  echo " - X: ", dev.event_x
+  echo " - Y: ", dev.event_y
+  # Print Pen Pressure
+  block: # Lookup Pressure
+    var p_dev: ptr GUIDevice
+    for item in mitems(devices):
+      if item.id == dev.sourceid:
+        p_dev = addr item
+    # Found Valid Device?
+    if not isNil(p_dev):
+      if XIMaskIsSet(dev.valuators.mask, p_dev.pnum) == 0:
+        echo " - Pressure: not found"
+      else: # Lookup Pressure
+        var current: int
+        for i in 0..<p_dev.pnum:
+          if XIMaskIsSet(dev.valuators.mask, i) != 0:
+            inc(current)
+        # Get Raw Pressure
+        let pressure = cast[ptr UncheckedArray[cdouble]](
+          dev.valuators.values)[current]
+        echo " - Raw Pressure: ", pressure
+        echo " - Pressure: ", (pressure - p_dev.pmin) / (p_dev.pmax - p_dev.pmin)
+
+proc mainLoop() =
+  ## Process events until the quit event is received
+  var event: XEvent
+  while true:
+    discard XNextEvent(display, event.addr)
+    case event.theType
+    of Expose:
+      drawWindow()
+    of ClientMessage:
+      if cast[Atom](event.xclient.data.l[0]) == deleteMessage:
+        break
+    of KeyPress:
+      let key = XLookupKeysym(cast[PXKeyEvent](event.addr), 0)
+      if key != 0:
+        echo "Key ", key, " pressed"
+    of ButtonPressMask:
+      echo "Mouse button ", event.xbutton.button, " pressed at ",
+          event.xbutton.x, ",", event.xbutton.y
+    of GenericEvent:
+      let data = XGetEventData(display, addr event.xcookie)
+      if data != 0: # Process Event if Valid
+        processGeneric(addr event)
+        XFreeEventData(display, addr event.xcookie)
+    else:
+      discard
+
+proc main() =
+  init()
+  mainLoop()
+  discard XDestroyWindow(display, window)
+  discard XCloseDisplay(display)
+
+
+main()

--- a/x11/x.nim
+++ b/x11/x.nim
@@ -147,7 +147,8 @@ const
   ColormapNotify* = 32
   ClientMessage* = 33
   MappingNotify* = 34
-  LASTEvent* = 35
+  GenericEvent* = 35
+  LASTEvent* = 36
   ShiftMask* = 1 shl 0
   LockMask* = 1 shl 1
   ControlMask* = 1 shl 2

--- a/x11/xi2.nim
+++ b/x11/xi2.nim
@@ -1,29 +1,9 @@
+# *************************************
+# Generated from <X11/extensions/XI2.h>
+# *************************************
+
 from xi import libXi
 export libXi
-
-##
-##  Copyright © 2009 Red Hat, Inc.
-##
-##  Permission is hereby granted, free of charge, to any person obtaining a
-##  copy of this software and associated documentation files (the "Software"),
-##  to deal in the Software without restriction, including without limitation
-##  the rights to use, copy, modify, merge, publish, distribute, sublicense,
-##  and/or sell copies of the Software, and to permit persons to whom the
-##  Software is furnished to do so, subject to the following conditions:
-##
-##  The above copyright notice and this permission notice (including the next
-##  paragraph) shall be included in all copies or substantial portions of the
-##  Software.
-##
-##  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-##  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-##  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
-##  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-##  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-##  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-##  DEALINGS IN THE SOFTWARE.
-##
-##
 
 const
   XInput_2_0* = 7

--- a/x11/xi2.nim
+++ b/x11/xi2.nim
@@ -223,15 +223,15 @@ const
 ##  XI2 event mask macros
 type XIMask = ptr UncheckedArray[uint8]
 
-template XISetMask*(mask, event: untyped): untyped =
+template XISetMask*(mask: pointer, event: untyped): untyped =
   ((cast[XIMask]((mask)))[(event) shr 3] = (cast[XIMask]((mask)))[
       (event) shr 3] or (1 shl ((event) and 7)))
 
-template XIClearMask*(mask, event: untyped): untyped =
+template XIClearMask*(mask: pointer, event: untyped): untyped =
   ((cast[XIMask]((mask)))[(event) shr 3] = (cast[XIMask]((mask)))[
       (event) shr 3] and not (1 shl ((event) and 7)))
 
-template XIMaskIsSet*(mask, event: untyped): untyped =
+template XIMaskIsSet*(mask: pointer, event: untyped): untyped =
   ((cast[XIMask]((mask)))[(event) shr 3].int and (1 shl ((event) and 7)))
 
 template XIMaskLen*(event: untyped): untyped =

--- a/x11/xi2.nim
+++ b/x11/xi2.nim
@@ -1,0 +1,311 @@
+from xi import libXi
+export libXi
+
+##
+##  Copyright © 2009 Red Hat, Inc.
+##
+##  Permission is hereby granted, free of charge, to any person obtaining a
+##  copy of this software and associated documentation files (the "Software"),
+##  to deal in the Software without restriction, including without limitation
+##  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+##  and/or sell copies of the Software, and to permit persons to whom the
+##  Software is furnished to do so, subject to the following conditions:
+##
+##  The above copyright notice and this permission notice (including the next
+##  paragraph) shall be included in all copies or substantial portions of the
+##  Software.
+##
+##  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+##  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+##  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+##  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+##  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+##  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+##  DEALINGS IN THE SOFTWARE.
+##
+##
+
+const
+  XInput_2_0* = 7
+
+##  DO NOT ADD TO THIS LIST. These are libXi-specific defines.
+##    See commit libXi-1.4.2-21-ge8531dd
+
+const
+  XI_2_Major* = 2
+  XI_2_Minor* = 3
+
+##  Property event flags
+
+const
+  XIPropertyDeleted* = 0
+  XIPropertyCreated* = 1
+  XIPropertyModified* = 2
+
+##  Property modes
+
+const
+  XIPropModeReplace* = 0
+  XIPropModePrepend* = 1
+  XIPropModeAppend* = 2
+
+##  Special property type used for XIGetProperty
+
+const
+  XIAnyPropertyType* = 0
+
+##  Enter/Leave and Focus In/Out modes
+
+const
+  XINotifyNormal* = 0
+  XINotifyGrab* = 1
+  XINotifyUngrab* = 2
+  XINotifyWhileGrabbed* = 3
+  XINotifyPassiveGrab* = 4
+  XINotifyPassiveUngrab* = 5
+
+##  Enter/Leave and focus In/out detail
+
+const
+  XINotifyAncestor* = 0
+  XINotifyVirtual* = 1
+  XINotifyInferior* = 2
+  XINotifyNonlinear* = 3
+  XINotifyNonlinearVirtual* = 4
+  XINotifyPointer* = 5
+  XINotifyPointerRoot* = 6
+  XINotifyDetailNone* = 7
+
+##  Grab modes
+
+const
+  XIGrabModeSync* = 0
+  XIGrabModeAsync* = 1
+  XIGrabModeTouch* = 2
+
+##  Grab reply status codes
+
+const
+  XIGrabSuccess* = 0
+  XIAlreadyGrabbed* = 1
+  XIGrabInvalidTime* = 2
+  XIGrabNotViewable* = 3
+  XIGrabFrozen* = 4
+
+##  Grab owner events values
+
+const
+  XIOwnerEvents* = true
+  XINoOwnerEvents* = false
+
+##  Passive grab types
+
+const
+  XIGrabtypeButton* = 0
+  XIGrabtypeKeycode* = 1
+  XIGrabtypeEnter* = 2
+  XIGrabtypeFocusIn* = 3
+  XIGrabtypeTouchBegin* = 4
+
+##  Passive grab modifier
+
+const
+  XIAnyModifier* = (1 shl 31)
+  XIAnyButton* = 0
+  XIAnyKeycode* = 0
+
+##  XIAllowEvents event-modes
+
+const
+  XIAsyncDevice* = 0
+  XISyncDevice* = 1
+  XIReplayDevice* = 2
+  XIAsyncPairedDevice* = 3
+  XIAsyncPair* = 4
+  XISyncPair* = 5
+  XIAcceptTouch* = 6
+  XIRejectTouch* = 7
+
+##  DeviceChangedEvent change reasons
+
+const
+  XISlaveSwitch* = 1
+  XIDeviceChange* = 2
+
+##  Hierarchy flags
+
+const
+  XIMasterAdded* = (1 shl 0)
+  XIMasterRemoved* = (1 shl 1)
+  XISlaveAdded* = (1 shl 2)
+  XISlaveRemoved* = (1 shl 3)
+  XISlaveAttached* = (1 shl 4)
+  XISlaveDetached* = (1 shl 5)
+  XIDeviceEnabled* = (1 shl 6)
+  XIDeviceDisabled* = (1 shl 7)
+
+##  ChangeHierarchy constants
+
+const
+  XIAddMaster* = 1
+  XIRemoveMaster* = 2
+  XIAttachSlave* = 3
+  XIDetachSlave* = 4
+  XIAttachToMaster* = 1
+  XIFloating* = 2
+
+##  Valuator modes
+
+const
+  XIModeRelative* = 0
+  XIModeAbsolute* = 1
+
+##  Device types
+
+const
+  XIMasterPointer* = 1
+  XIMasterKeyboard* = 2
+  XISlavePointer* = 3
+  XISlaveKeyboard* = 4
+  XIFloatingSlave* = 5
+
+##  Device classes: classes that are not identical to Xi 1.x classes must be
+##  numbered starting from 8.
+
+const
+  XIKeyClass* = 0
+  XIButtonClass* = 1
+  XIValuatorClass* = 2
+  XIScrollClass* = 3
+  XITouchClass* = 8
+
+##  Scroll class types
+
+const
+  XIScrollTypeVertical* = 1
+  XIScrollTypeHorizontal* = 2
+
+##  Scroll class flags
+
+const
+  XIScrollFlagNoEmulation* = (1 shl 0)
+  XIScrollFlagPreferred* = (1 shl 1)
+
+##  Device event flags (common)
+##  Device event flags (key events only)
+
+const
+  XIKeyRepeat* = (1 shl 16)
+
+##  Device event flags (pointer events only)
+
+const
+  XIPointerEmulated* = (1 shl 16)
+
+##  Device event flags (touch events only)
+
+const
+  XITouchPendingEnd* = (1 shl 16)
+  XITouchEmulatingPointer* = (1 shl 17)
+
+##  Barrier event flags
+
+const
+  XIBarrierPointerReleased* = (1 shl 0)
+  XIBarrierDeviceIsGrabbed* = (1 shl 1)
+
+##  Touch modes
+
+const
+  XIDirectTouch* = 1
+  XIDependentTouch* = 2
+
+##  XI2 event mask macros
+type XIMask = ptr UncheckedArray[uint8]
+
+template XISetMask*(mask, event: untyped): untyped =
+  ((cast[XIMask]((mask)))[(event) shr 3] = (cast[XIMask]((mask)))[
+      (event) shr 3] or (1 shl ((event) and 7)))
+
+template XIClearMask*(mask, event: untyped): untyped =
+  ((cast[XIMask]((mask)))[(event) shr 3] = (cast[XIMask]((mask)))[
+      (event) shr 3] and not (1 shl ((event) and 7)))
+
+template XIMaskIsSet*(mask, event: untyped): untyped =
+  ((cast[XIMask]((mask)))[(event) shr 3].int and (1 shl ((event) and 7)))
+
+template XIMaskLen*(event: untyped): untyped =
+  (((event) shr 3) + 1)
+
+##  Fake device ID's for event selection
+
+const
+  XIAllDevices* = 0
+  XIAllMasterDevices* = 1
+
+##  Event types
+
+const
+  XI_DeviceChanged* = 1
+  XI_KeyPress* = 2
+  XI_KeyRelease* = 3
+  XI_ButtonPress* = 4
+  XI_ButtonRelease* = 5
+  XI_Motion* = 6
+  XI_Enter* = 7
+  XI_Leave* = 8
+  XI_FocusIn* = 9
+  XI_FocusOut* = 10
+  XI_HierarchyChanged* = 11
+  XI_PropertyEvent* = 12
+  XI_RawKeyPress* = 13
+  XI_RawKeyRelease* = 14
+  XI_RawButtonPress* = 15
+  XI_RawButtonRelease* = 16
+  XI_RawMotion* = 17
+  XI_TouchBegin* = 18
+  XI_TouchUpdate* = 19
+  XI_TouchEnd* = 20
+  XI_TouchOwnership* = 21
+  XI_RawTouchBegin* = 22
+  XI_RawTouchUpdate* = 23
+  XI_RawTouchEnd* = 24
+  XI_BarrierHit* = 25
+  XI_BarrierLeave* = 26
+  XI_LASTEVENT* = XI_BarrierLeave
+
+##  NOTE: XI2LASTEVENT in xserver/include/inputstr.h must be the same value
+##  as XI_LASTEVENT if the server is supposed to handle masks etc. for this
+##  type of event.
+##  Event masks.
+##  Note: the protocol spec defines a mask to be of (1 << type). Clients are
+##  free to create masks by bitshifting instead of using these defines.
+##
+
+const
+  XI_DeviceChangedMask* = (1 shl XI_DeviceChanged)
+  XI_KeyPressMask* = (1 shl XI_KeyPress)
+  XI_KeyReleaseMask* = (1 shl XI_KeyRelease)
+  XI_ButtonPressMask* = (1 shl XI_ButtonPress)
+  XI_ButtonReleaseMask* = (1 shl XI_ButtonRelease)
+  XI_MotionMask* = (1 shl XI_Motion)
+  XI_EnterMask* = (1 shl XI_Enter)
+  XI_LeaveMask* = (1 shl XI_Leave)
+  XI_FocusInMask* = (1 shl XI_FocusIn)
+  XI_FocusOutMask* = (1 shl XI_FocusOut)
+  XI_HierarchyChangedMask* = (1 shl XI_HierarchyChanged)
+  XI_PropertyEventMask* = (1 shl XI_PropertyEvent)
+  XI_RawKeyPressMask* = (1 shl XI_RawKeyPress)
+  XI_RawKeyReleaseMask* = (1 shl XI_RawKeyRelease)
+  XI_RawButtonPressMask* = (1 shl XI_RawButtonPress)
+  XI_RawButtonReleaseMask* = (1 shl XI_RawButtonRelease)
+  XI_RawMotionMask* = (1 shl XI_RawMotion)
+  XI_TouchBeginMask* = (1 shl XI_TouchBegin)
+  XI_TouchEndMask* = (1 shl XI_TouchEnd)
+  XI_TouchOwnershipChangedMask* = (1 shl XI_TouchOwnership)
+  XI_TouchUpdateMask* = (1 shl XI_TouchUpdate)
+  XI_RawTouchBeginMask* = (1 shl XI_RawTouchBegin)
+  XI_RawTouchEndMask* = (1 shl XI_RawTouchEnd)
+  XI_RawTouchUpdateMask* = (1 shl XI_RawTouchUpdate)
+  XI_BarrierHitMask* = (1 shl XI_BarrierHit)
+  XI_BarrierLeaveMask* = (1 shl XI_BarrierLeave)

--- a/x11/xinput2.nim
+++ b/x11/xinput2.nim
@@ -1,34 +1,10 @@
+# *****************************************
+# Generated from <X11/extensions/XInput2.h>
+# *****************************************
 import x, xlib, xi2
 
-##
-##  Copyright © 2009 Red Hat, Inc.
-##
-##  Permission is hereby granted, free of charge, to any person obtaining a
-##  copy of this software and associated documentation files (the "Software"),
-##  to deal in the Software without restriction, including without limitation
-##  the rights to use, copy, modify, merge, publish, distribute, sublicense,
-##  and/or sell copies of the Software, and to permit persons to whom the
-##  Software is furnished to do so, subject to the following conditions:
-##
-##  The above copyright notice and this permission notice (including the next
-##  paragraph) shall be included in all copies or substantial portions of the
-##  Software.
-##
-##  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-##  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-##  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
-##  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-##  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-##  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-##  DEALINGS IN THE SOFTWARE.
-##
-##
-##  Definitions used by the library and client
-
-## From <X11/extensions/xfixes.h>
+# <X11/extensions/xfixes.h>
 type PointerBarrier* = XID
-
-## ******************************************************************
 
 type
   PXIAddMasterInfo* = ptr XIAddMasterInfo

--- a/x11/xinput2.nim
+++ b/x11/xinput2.nim
@@ -1,0 +1,445 @@
+import x, xlib, xi2
+
+##
+##  Copyright © 2009 Red Hat, Inc.
+##
+##  Permission is hereby granted, free of charge, to any person obtaining a
+##  copy of this software and associated documentation files (the "Software"),
+##  to deal in the Software without restriction, including without limitation
+##  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+##  and/or sell copies of the Software, and to permit persons to whom the
+##  Software is furnished to do so, subject to the following conditions:
+##
+##  The above copyright notice and this permission notice (including the next
+##  paragraph) shall be included in all copies or substantial portions of the
+##  Software.
+##
+##  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+##  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+##  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+##  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+##  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+##  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+##  DEALINGS IN THE SOFTWARE.
+##
+##
+##  Definitions used by the library and client
+
+## From <X11/extensions/xfixes.h>
+type PointerBarrier* = XID
+
+## ******************************************************************
+
+type
+  PXIAddMasterInfo* = ptr XIAddMasterInfo
+  XIAddMasterInfo* {.final.} = object
+    `type`*: cint
+    name*: cstring
+    send_core*: XBool
+    enable*: XBool
+
+  PXIRemoveMasterInfo* = ptr XIRemoveMasterInfo
+  XIRemoveMasterInfo* {.final.} = object
+    `type`*: cint
+    deviceid*: cint
+    return_mode*: cint         ##  AttachToMaster, Floating
+    return_pointer*: cint
+    return_keyboard*: cint
+
+  PXIAttachSlaveInfo* = ptr XIAttachSlaveInfo
+  XIAttachSlaveInfo* {.final.} = object
+    `type`*: cint
+    deviceid*: cint
+    new_master*: cint
+
+  PXIDetachSlaveInfo* = ptr XIDetachSlaveInfo
+  XIDetachSlaveInfo* {.final.} = object
+    `type`*: cint
+    deviceid*: cint
+
+  PXIAnyHierarchyChangeInfo* = ptr XIAnyHierarchyChangeInfo
+  XIAnyHierarchyChangeInfo* {.final, union.} = object
+    `type`*: cint              ##  must be first element
+    add*: XIAddMasterInfo
+    remove*: XIRemoveMasterInfo
+    attach*: XIAttachSlaveInfo
+    detach*: XIDetachSlaveInfo
+
+  PXIModifierState* = ptr XIModifierState
+  XIModifierState* {.final.} = object
+    base*: cint
+    latched*: cint
+    locked*: cint
+    effective*: cint
+
+  PXIGroupState* = ptr XIGroupState
+  XIGroupState* = XIModifierState
+
+  PXIButtonState* = ptr XIButtonState
+  XIButtonState* {.final.} = object
+    mask_len*: cint
+    mask*: ptr cuchar
+
+  PXIValuatorState* = ptr XIValuatorState
+  XIValuatorState* {.final.} = object
+    mask_len*: cint
+    mask*: ptr cuchar
+    values*: ptr cdouble
+
+  PXIEventMask* = ptr XIEventMask
+  XIEventMask* {.final.} = object
+    deviceid*: cint
+    mask_len*: cint
+    mask*: ptr cuchar
+
+  PXIAnyClassInfo* = ptr XIAnyClassInfo
+  XIAnyClassInfo* {.final.} = object
+    `type`*: cint
+    sourceid*: cint
+
+  PXIButtonClassInfo* = ptr XIButtonClassInfo
+  XIButtonClassInfo* {.final.} = object
+    `type`*: cint
+    sourceid*: cint
+    num_buttons*: cint
+    labels*: PAtom
+    state*: XIButtonState
+
+  PXIKeyClassInfo* = ptr XIKeyClassInfo
+  XIKeyClassInfo* {.final.} = object
+    `type`*: cint
+    sourceid*: cint
+    num_keycodes*: cint
+    keycodes*: ptr cint
+
+  PXIValuatorClassInfo* = ptr XIValuatorClassInfo
+  XIValuatorClassInfo* {.final.} = object
+    `type`*: cint
+    sourceid*: cint
+    number*: cint
+    label*: Atom
+    min*: cdouble
+    max*: cdouble
+    value*: cdouble
+    resolution*: cint
+    mode*: cint
+
+
+##  new in XI 2.1
+
+type
+  PXIScrollClassInfo* = ptr XIScrollClassInfo
+  XIScrollClassInfo* {.final.} = object
+    `type`*: cint
+    sourceid*: cint
+    number*: cint
+    scroll_type*: cint
+    increment*: cdouble
+    flags*: cint
+
+  PXITouchClassInfo* = ptr XITouchClassInfo
+  XITouchClassInfo* {.final.} = object
+    `type`*: cint
+    sourceid*: cint
+    mode*: cint
+    num_touches*: cint
+
+  PXIDeviceInfo* = ptr XIDeviceInfo
+  XIDeviceInfo* {.final.} = object
+    deviceid*: cint
+    name*: cstring
+    use*: cint
+    attachment*: cint
+    enabled*: XBool
+    num_classes*: cint
+    classes*: ptr ptr XIAnyClassInfo
+
+  PXIGrabModifiers* = ptr XIGrabModifiers
+  XIGrabModifiers* {.final.} = object
+    modifiers*: cint
+    status*: cint
+
+  BarrierEventID* = cuint
+  # ------------------------------------------------------------
+  PXIBarrierReleasePointerInfo* = ptr XIBarrierReleasePointerInfo
+  XIBarrierReleasePointerInfo* {.final.} = object
+    deviceid*: cint
+    barrier*: PointerBarrier
+    eventid*: BarrierEventID
+
+##
+##  Generic XI2 event. All XI2 events have the same header.
+##
+
+type
+  PXIEvent* = ptr XIEvent
+  XIEvent* {.final.} = object
+    `type`*: cint              ##  GenericEvent
+    serial*: culong            ##  # of last request processed by server
+    send_event*: XBool          ##  true if this came from a SendEvent request
+    display*: PDisplay       ##  Display the event was read from
+    extension*: cint           ##  XI extension offset
+    evtype*: cint
+    time*: Time
+
+  PXIHierarchyInfo* = ptr XIHierarchyInfo
+  XIHierarchyInfo* {.final.} = object
+    deviceid*: cint
+    attachment*: cint
+    use*: cint
+    enabled*: XBool
+    flags*: cint
+
+##
+##  Notifies the client that the device hierarchy has been changed. The client
+##  is expected to re-query the server for the device hierarchy.
+##
+
+type
+  PXIHierarchyEvent* = ptr XIHierarchyEvent
+  XIHierarchyEvent* {.final.} = object
+    `type`*: cint              ##  GenericEvent
+    serial*: culong            ##  # of last request processed by server
+    send_event*: XBool          ##  true if this came from a SendEvent request
+    display*: PDisplay       ##  Display the event was read from
+    extension*: cint           ##  XI extension offset
+    evtype*: cint              ##  XI_HierarchyChanged
+    time*: Time
+    flags*: cint
+    num_info*: cint
+    info*: ptr XIHierarchyInfo
+
+##
+##  Notifies the client that the classes have been changed. This happens when
+##  the slave device that sends through the master changes.
+##
+
+type
+  PXIDeviceChangedEvent* = ptr XIDeviceChangedEvent
+  XIDeviceChangedEvent* {.final.} = object
+    `type`*: cint              ##  GenericEvent
+    serial*: culong            ##  # of last request processed by server
+    send_event*: XBool          ##  true if this came from a SendEvent request
+    display*: PDisplay       ##  Display the event was read from
+    extension*: cint           ##  XI extension offset
+    evtype*: cint              ##  XI_DeviceChanged
+    time*: Time
+    deviceid*: cint            ##  id of the device that changed
+    sourceid*: cint            ##  Source for the new classes.
+    reason*: cint              ##  Reason for the change
+    num_classes*: cint
+    classes*: ptr ptr XIAnyClassInfo ##  same as in XIDeviceInfo
+
+  PXIDeviceEvent* = ptr XIDeviceEvent
+  XIDeviceEvent* {.final.} = object
+    `type`*: cint              ##  GenericEvent
+    serial*: culong            ##  # of last request processed by server
+    send_event*: XBool          ##  true if this came from a SendEvent request
+    display*: PDisplay       ##  Display the event was read from
+    extension*: cint           ##  XI extension offset
+    evtype*: cint
+    time*: Time
+    deviceid*: cint
+    sourceid*: cint
+    detail*: cint
+    root*: Window
+    event*: Window
+    child*: Window
+    root_x*: cdouble
+    root_y*: cdouble
+    event_x*: cdouble
+    event_y*: cdouble
+    flags*: cint
+    buttons*: XIButtonState
+    valuators*: XIValuatorState
+    mods*: XIModifierState
+    group*: XIGroupState
+
+  PXIRawEvent* = ptr XIRawEvent
+  XIRawEvent* {.final.} = object
+    `type`*: cint              ##  GenericEvent
+    serial*: culong            ##  # of last request processed by server
+    send_event*: XBool          ##  true if this came from a SendEvent request
+    display*: PDisplay       ##  Display the event was read from
+    extension*: cint           ##  XI extension offset
+    evtype*: cint              ##  XI_RawKeyPress, XI_RawKeyRelease, etc.
+    time*: Time
+    deviceid*: cint
+    sourceid*: cint            ##  Bug: Always 0. https://bugs.freedesktop.org//show_bug.cgi?id=34240
+    detail*: cint
+    flags*: cint
+    valuators*: XIValuatorState
+    raw_values*: ptr cdouble
+
+  PXIEnterEvent* = ptr XIEnterEvent
+  XIEnterEvent* {.final.} = object
+    `type`*: cint              ##  GenericEvent
+    serial*: culong            ##  # of last request processed by server
+    send_event*: XBool          ##  true if this came from a SendEvent request
+    display*: PDisplay       ##  Display the event was read from
+    extension*: cint           ##  XI extension offset
+    evtype*: cint
+    time*: Time
+    deviceid*: cint
+    sourceid*: cint
+    detail*: cint
+    root*: Window
+    event*: Window
+    child*: Window
+    root_x*: cdouble
+    root_y*: cdouble
+    event_x*: cdouble
+    event_y*: cdouble
+    mode*: cint
+    focus*: XBool
+    same_screen*: XBool
+    buttons*: XIButtonState
+    mods*: XIModifierState
+    group*: XIGroupState
+
+  PXILeaveEvent* = PXIEnterEvent
+  PXIFocusInEvent* = PXIEnterEvent
+  PXIFocusOutEvent* = PXIEnterEvent
+  # ----------------------------------
+  XILeaveEvent* = XIEnterEvent
+  XIFocusInEvent* = XIEnterEvent
+  XIFocusOutEvent* = XIEnterEvent
+
+  PXIPropertyEvent* = ptr XIPropertyEvent
+  XIPropertyEvent* {.final.} = object
+    `type`*: cint              ##  GenericEvent
+    serial*: culong            ##  # of last request processed by server
+    send_event*: XBool          ##  true if this came from a SendEvent request
+    display*: PDisplay       ##  Display the event was read from
+    extension*: cint           ##  XI extension offset
+    evtype*: cint              ##  XI_PropertyEvent
+    time*: Time
+    deviceid*: cint            ##  id of the device that changed
+    property*: Atom
+    what*: cint
+
+  PXITouchOwnershipEvent* = ptr XITouchOwnershipEvent
+  XITouchOwnershipEvent* {.final.} = object
+    `type`*: cint              ##  GenericEvent
+    serial*: culong            ##  # of last request processed by server
+    send_event*: XBool          ##  true if this came from a SendEvent request
+    display*: PDisplay       ##  Display the event was read from
+    extension*: cint           ##  XI extension offset
+    evtype*: cint
+    time*: Time
+    deviceid*: cint
+    sourceid*: cint
+    touchid*: cuint
+    root*: Window
+    event*: Window
+    child*: Window
+    flags*: cint
+
+  PXIBarrierEvent* = ptr XIBarrierEvent
+  XIBarrierEvent* {.final.} = object
+    `type`*: cint              ##  GenericEvent
+    serial*: culong            ##  # of last request processed by server
+    send_event*: XBool          ##  true if this came from a SendEvent request
+    display*: PDisplay       ##  Display the event was read from
+    extension*: cint           ##  XI extension offset
+    evtype*: cint
+    time*: Time
+    deviceid*: cint
+    sourceid*: cint
+    event*: Window
+    root*: Window
+    root_x*: cdouble
+    root_y*: cdouble
+    dx*: cdouble
+    dy*: cdouble
+    dtime*: cint
+    flags*: cint
+    barrier*: PointerBarrier
+    eventid*: BarrierEventID
+
+##
+## XI2 Procs, uses same shared object as XI
+##
+ 
+{.push cdecl, importc, dynlib: libXi.}
+
+proc XIQueryPointer*(display: PDisplay; deviceid: cint; win: Window;
+                    root: PWindow; child: PWindow; root_x: ptr cdouble;
+                    root_y: ptr cdouble; win_x: ptr cdouble; win_y: ptr cdouble;
+                    buttons: PXIButtonState; mods: PXIModifierState;
+                    group: PXIGroupState): XBool
+proc XIWarpPointer*(display: PDisplay; deviceid: cint; src_win: Window;
+                   dst_win: Window; src_x: cdouble; src_y: cdouble; src_width: cuint;
+                   src_height: cuint; dst_x: cdouble; dst_y: cdouble): XBool
+proc XIDefineCursor*(display: PDisplay; deviceid: cint; win: Window; cursor: Cursor): Status
+proc XIUndefineCursor*(display: PDisplay; deviceid: cint; win: Window): Status
+proc XIChangeHierarchy*(display: PDisplay; changes: PXIAnyHierarchyChangeInfo;
+                       num_changes: cint): Status
+proc XISetClientPointer*(dpy: PDisplay; win: Window; deviceid: cint): Status
+proc XIGetClientPointer*(dpy: PDisplay; win: Window; deviceid: ptr cint): XBool
+proc XISelectEvents*(dpy: PDisplay; win: Window; masks: PXIEventMask;
+                    num_masks: cint): cint
+proc XIGetSelectedEvents*(dpy: PDisplay; win: Window; num_masks_return: ptr cint): PXIEventMask
+proc XIQueryVersion*(dpy: PDisplay; major_version_inout: ptr cint;
+                    minor_version_inout: ptr cint): Status
+proc XIQueryDevice*(dpy: PDisplay; deviceid: cint; ndevices_return: ptr cint): PXIDeviceInfo
+proc XISetFocus*(dpy: PDisplay; deviceid: cint; focus: Window; time: Time): Status
+proc XIGetFocus*(dpy: PDisplay; deviceid: cint; focus_return: PWindow): Status
+proc XIGrabDevice*(dpy: PDisplay; deviceid: cint; grab_window: Window; time: Time;
+                  cursor: Cursor; grab_mode: cint; paired_device_mode: cint;
+                  owner_events: XBool; mask: PXIEventMask): Status
+proc XIUngrabDevice*(dpy: PDisplay; deviceid: cint; time: Time): Status
+proc XIAllowEvents*(display: PDisplay; deviceid: cint; event_mode: cint; time: Time): Status
+proc XIAllowTouchEvents*(display: PDisplay; deviceid: cint; touchid: cuint;
+                        grab_window: Window; event_mode: cint): Status
+proc XIGrabButton*(display: PDisplay; deviceid: cint; button: cint;
+                  grab_window: Window; cursor: Cursor; grab_mode: cint;
+                  paired_device_mode: cint; owner_events: cint;
+                  mask: PXIEventMask; num_modifiers: cint;
+                  modifiers_inout: PXIGrabModifiers): cint
+proc XIGrabKeycode*(display: PDisplay; deviceid: cint; keycode: cint;
+                   grab_window: Window; grab_mode: cint; paired_device_mode: cint;
+                   owner_events: cint; mask: PXIEventMask; num_modifiers: cint;
+                   modifiers_inout: PXIGrabModifiers): cint
+proc XIGrabEnter*(display: PDisplay; deviceid: cint; grab_window: Window;
+                 cursor: Cursor; grab_mode: cint; paired_device_mode: cint;
+                 owner_events: cint; mask: PXIEventMask; num_modifiers: cint;
+                 modifiers_inout: PXIGrabModifiers): cint
+proc XIGrabFocusIn*(display: PDisplay; deviceid: cint; grab_window: Window;
+                   grab_mode: cint; paired_device_mode: cint; owner_events: cint;
+                   mask: PXIEventMask; num_modifiers: cint;
+                   modifiers_inout: PXIGrabModifiers): cint
+proc XIGrabTouchBegin*(display: PDisplay; deviceid: cint; grab_window: Window;
+                      owner_events: cint; mask: PXIEventMask; num_modifiers: cint;
+                      modifiers_inout: PXIGrabModifiers): cint
+proc XIUngrabButton*(display: PDisplay; deviceid: cint; button: cint;
+                    grab_window: Window; num_modifiers: cint;
+                    modifiers: PXIGrabModifiers): Status
+proc XIUngrabKeycode*(display: PDisplay; deviceid: cint; keycode: cint;
+                     grab_window: Window; num_modifiers: cint;
+                     modifiers: PXIGrabModifiers): Status
+proc XIUngrabEnter*(display: PDisplay; deviceid: cint; grab_window: Window;
+                   num_modifiers: cint; modifiers: PXIGrabModifiers): Status
+proc XIUngrabFocusIn*(display: PDisplay; deviceid: cint; grab_window: Window;
+                     num_modifiers: cint; modifiers: PXIGrabModifiers): Status
+proc XIUngrabTouchBegin*(display: PDisplay; deviceid: cint; grab_window: Window;
+                        num_modifiers: cint; modifiers: PXIGrabModifiers): Status
+proc XIListProperties*(display: PDisplay; deviceid: cint;
+                      num_props_return: ptr cint): PAtom
+proc XIChangeProperty*(display: PDisplay; deviceid: cint; property: Atom;
+                      `type`: Atom; format: cint; mode: cint; data: ptr cuchar;
+                      num_items: cint)
+proc XIDeleteProperty*(display: PDisplay; deviceid: cint; property: Atom)
+proc XIGetProperty*(display: PDisplay; deviceid: cint; property: Atom; offset: clong;
+                   length: clong; delete_property: XBool; `type`: Atom;
+                   type_return: PAtom; format_return: ptr cint;
+                   num_items_return: ptr culong; bytes_after_return: ptr culong;
+                   data: ptr ptr cuchar): Status
+proc XIBarrierReleasePointers*(display: PDisplay;
+                              barriers: PXIBarrierReleasePointerInfo;
+                              num_barriers: cint)
+proc XIBarrierReleasePointer*(display: PDisplay; deviceid: cint;
+                             barrier: PointerBarrier; eventid: BarrierEventID)
+proc XIFreeDeviceInfo*(info: PXIDeviceInfo)
+
+{.pop.}

--- a/x11/xlib.nim
+++ b/x11/xlib.nim
@@ -737,6 +737,26 @@ type
     display*: PDisplay
     window*: Window
 
+  PXGenericEvent* = ptr XGenericEvent
+  XGenericEvent*{.final.} = object
+    theType*: cint              ##  of event. Always GenericEvent
+    serial*: culong            ##  # of last request processed
+    send_event*: XBool          ##  true if from SendEvent request
+    display*: PDisplay       ##  Display the event was read from
+    extension*: cint           ##  major opcode of extension that caused the event
+    evtype*: cint              ##  actual event type.
+
+  PXGenericEventCookie* = ptr XGenericEventCookie
+  XGenericEventCookie*{.final.} = object
+    theType*: cint              ##  of event. Always GenericEvent
+    serial*: culong            ##  # of last request processed
+    send_event*: XBool          ##  true if from SendEvent request
+    display*: PDisplay       ##  Display the event was read from
+    extension*: cint           ##  major opcode of extension that caused the event
+    evtype*: cint              ##  actual event type.
+    cookie*: cuint
+    data*: pointer
+
   PXEvent* = ptr XEvent
   XEvent*{.final, union.} = object
     theType*: cint
@@ -771,6 +791,8 @@ type
     xmapping*: XMappingEvent
     xerror*: XErrorEvent
     xkeymap*: XKeymapEvent
+    xgeneric*: XGenericEvent
+    xcookie*: XGenericEventCookie
     pad: array[0..23, clong]
 
 {.deprecated: [TXExtData: XExtData].}
@@ -1968,6 +1990,8 @@ proc XSetAuthorization*(para1: cstring, para2: cint, para3: cstring, para4: cint
   #  _Xmbtowc?
   #  _Xwctomb?
   #
+proc XGetEventData*(para1: PDisplay, para2: PXGenericEventCookie): XBool {.libX11.}
+proc XFreeEventData*(para1: PDisplay, para2: PXGenericEventCookie) {.libX11.}
 #when defined(MACROS):
 proc ConnectionNumber*(dpy: PDisplay): cint
 proc RootWindow*(dpy: PDisplay, scr: cint): Window


### PR DESCRIPTION
Includes a simple example for tablet pen pressure, T prefixes not added because deprecation.
PD: Xge extends xlib.h adding only XGenericEvent and XGenericEventCookie which are the base for modern extensions like XI2